### PR TITLE
use of bbob2009_fmax instead of fmax since it seems to make the windows builds fail

### DIFF
--- a/code-experiments/src/large_scale_transformations.c
+++ b/code-experiments/src/large_scale_transformations.c
@@ -291,7 +291,7 @@ size_t *ls_get_block_sizes(size_t *nb_blocks, size_t dimension){
   size_t block_size;
   int i;
   
-  block_size = (size_t) fmin(dimension / 4, 100);
+  block_size = (size_t) bbob2009_fmin(dimension / 4, 100);
   *nb_blocks = dimension / block_size + ((dimension % block_size) > 0);
   block_sizes = (size_t *)coco_allocate_memory(*nb_blocks * sizeof(size_t));
   for (i = 0; i < *nb_blocks - 1; i++) {

--- a/code-experiments/src/logger_bbob.c
+++ b/code-experiments/src/logger_bbob.c
@@ -322,8 +322,8 @@ static void logger_bbob_initialize(logger_bbob_t *logger, coco_problem_t *inner_
   char indexFile_prefix[10] = "bbobexp"; /* TODO (minor): make the prefix bbobexp a parameter that the user can modify */
   size_t str_length_funId, str_length_dim;
   
-  str_length_funId = (size_t) fmax(1, ceil(log10(coco_problem_get_suite_dep_function(inner_problem))));
-  str_length_dim = (size_t) fmax(1, ceil(log10(inner_problem->number_of_variables)));
+  str_length_funId = (size_t) bbob2009_fmax(1, ceil(log10(coco_problem_get_suite_dep_function(inner_problem))));
+  str_length_dim = (size_t) bbob2009_fmax(1, ceil(log10(inner_problem->number_of_variables)));
   tmpc_funId = (char *) coco_allocate_memory(str_length_funId *  sizeof(char));
   tmpc_dim = (char *) coco_allocate_memory(str_length_dim *  sizeof(char));
 


### PR DESCRIPTION
use of bbob2009_fmax instead of fmax since it seems to make the windows builds fail