### PR TITLE
bugfix for post-processing testing on Linux machine

### DIFF
--- a/code-postprocessing/bbob_pproc/__init__.py
+++ b/code-postprocessing/bbob_pproc/__init__.py
@@ -24,6 +24,9 @@ from __future__ import absolute_import
 
 import sys
 
+import matplotlib  # just to make sure the following is actually done first
+matplotlib.use('Agg')  # To avoid window popup and use without X forwarding
+
 from .cococommands import *
 
 from .rungeneric import main as main

--- a/code-postprocessing/bbob_pproc/__main__.py
+++ b/code-postprocessing/bbob_pproc/__main__.py
@@ -18,6 +18,8 @@ try:
     is_module = True
 except:
     is_module = False
+import matplotlib  # just to make sure the following is actually done first
+matplotlib.use('Agg')  # To avoid window popup and use without X forwarding
 
 # depreciated, to be removed, see end of file
 if 11 < 3 and __name__ == "__main__" and not is_module:


### PR DESCRIPTION
make the postprocessing test run on Linux (adding matplotlib.use('Agg'))
	modified:   bbob_pproc/__init__.py
	modified:   bbob_pproc/__main__.py