### PR TITLE
fixed issue in observer

### DIFF
--- a/code-experiments/src/logger_biobj.c
+++ b/code-experiments/src/logger_biobj.c
@@ -508,7 +508,9 @@ static logger_biobj_indicator_t *logger_biobj_indicator(const logger_biobj_data_
     fprintf(indicator->info_file, "algorithm = '%s', indicator = '%s', folder = '%s'\n%% %s", observer->algorithm_name,
         indicator_name, problem->problem_type, observer->algorithm_info);
   }
-  if (observer_biobj->previous_function != problem->suite_dep_function) {
+  if (observer_biobj->previous_function != problem->suite_dep_function 
+    || observer_biobj->previous_number_of_variables != problem->number_of_variables
+  ) {
     fprintf(indicator->info_file, "\nfunction = %2lu, ", problem->suite_dep_function);
     fprintf(indicator->info_file, "dim = %2lu, ", problem->number_of_variables);
     fprintf(indicator->info_file, "%s", file_name);
@@ -850,6 +852,7 @@ static coco_problem_t *logger_biobj(coco_observer_t *observer, coco_problem_t *i
       logger_biobj->indicators[i] = logger_biobj_indicator(logger_biobj, observer, inner_problem, logger_biobj_indicators[i]);
 
     observer_biobj->previous_function = (long) inner_problem->suite_dep_function;
+    observer_biobj->previous_number_of_variables = (long) inner_problem->number_of_variables;
   }
 
   problem = coco_problem_transformed_allocate(inner_problem, logger_biobj, logger_biobj_free, observer->observer_name);

--- a/code-experiments/src/observer_biobj.c
+++ b/code-experiments/src/observer_biobj.c
@@ -29,7 +29,8 @@ typedef struct {
   int compute_indicators;                      /**< @brief Whether to compute indicators. */
   int produce_all_data;                        /**< @brief Whether to produce all data. */
 
-  long previous_function;                      /**< @brief Information on the previous logged problem. */
+  long previous_function;                      /**< @brief Function the previous logged problem. */
+  long previous_number_of_variables;  /**< @brief Dimensionality of the previous logged problem */
 
 } observer_biobj_data_t;
 
@@ -105,6 +106,7 @@ static void observer_biobj(coco_observer_t *observer, const char *options, coco_
 
   if (observer_biobj->compute_indicators) {
     observer_biobj->previous_function = -1;
+    observer_biobj->previous_number_of_variables = -1;
   }
 
   observer->logger_allocate_function = logger_biobj;


### PR DESCRIPTION
When the observer should log the indicator in the info file, it checks whether the current function is different from the previous function observed. It does not check whether the dimensionality is different. this breaks cases where the same function is evaluated in different dimensions.

problem came up in #707
