### PR TITLE
Fixing Memory Leaks and Backward Compatibility Issues in the Large-Scale Testsuite

### DIFF
--- a/code-experiments/src/transform_vars_permutation_helpers.c
+++ b/code-experiments/src/transform_vars_permutation_helpers.c
@@ -79,6 +79,7 @@ static void coco_compute_truncated_uniform_swap_permutation(size_t *P, long seed
   }
   if (dimension <= 40) {/* provisional solution to have the large-scale suite backward compatible with the bbob suite. Should probably take the value from the bbob suite itself.*/
     coco_random_free(rng);
+    coco_free_memory(idx_order);
     return; /* return the identity permutation*/
   }
   

--- a/code-postprocessing/cocopp/preparetexforhtml.py
+++ b/code-postprocessing/cocopp/preparetexforhtml.py
@@ -85,6 +85,9 @@ def main(latex_commands_for_html):
         elif scenario == testbedsettings.scenario_biobjextfixed:
             genericsettings.runlength_based_targets = False
             config.config(testbedsettings.default_testbed_bi_ext)
+        elif scenario == testbedsettings.scenario_largescalefixed:
+            genericsettings.runlength_based_targets = False
+            config.config(testbedsettings.default_testbed_largescale)
         else:
             warnings.warn("Scenario not supported yet in HTML")
 

--- a/code-postprocessing/cocopp/testbedsettings.py
+++ b/code-postprocessing/cocopp/testbedsettings.py
@@ -12,7 +12,7 @@ scenario_biobjextfixed = 'biobjextfixed'
 scenario_largescalefixed = 'largescalefixed'
 all_scenarios = [scenario_rlbased, scenario_fixed,
                  scenario_biobjfixed, scenario_biobjrlbased,
-                 scenario_biobjextfixed,scenario_largescalefixed]
+                 scenario_biobjextfixed, scenario_largescalefixed]
 
 testbed_name_single = 'bbob'
 testbed_name_single_noisy = 'bbob-noisy'


### PR DESCRIPTION
Added a temporary fix for #1102 `(if dimension <= 40)` and current tests showed that it should also fix  #1231 
( I now longer see increased memory usage when on a python console and running 
`suite = cocoex.Suite('bbob-largescale', '', 'dimensions:20,40,80,160,320,640')`
multiple times in the same python instance.)

Also, added large-scale scenario to `preparetexforhtml.py` which should, in theory and once rerun to update `latex_commands_for_html.html`, fix #1286 