### PR TITLE
Added option to specify Python package install location

### DIFF
--- a/code-experiments/tools/cocoutils.py
+++ b/code-experiments/tools/cocoutils.py
@@ -126,7 +126,7 @@ def run(directory, args, verbose=False):
     finally:
         os.chdir(oldwd)
 
-def python(directory, args, env=None, verbose=False):
+def python(directory, args, env=None, verbose=False, custom_exception_handler=None):
     print("PYTHON\t%s in %s" % (" ".join(args), directory))
     oldwd = os.getcwd()
     if env is not None:
@@ -144,9 +144,14 @@ def python(directory, args, env=None, verbose=False):
                               universal_newlines=True)
         # print(output)
     except CalledProcessError as e:
-        print("ERROR: return value=%i" % e.returncode)
-        print(e.output)
-        raise
+        if custom_exception_handler is None:
+            print("ERROR: return value=%i" % e.returncode)
+            print(e.output)
+            raise
+        else:
+            exception_handled = custom_exception_handler(e)
+            if not exception_handled:
+                raise
     finally:
         os.chdir(oldwd)
 

--- a/do.py
+++ b/do.py
@@ -236,14 +236,14 @@ def leak_check():
 
 ################################################################################
 ## Python 2
-def install_postprocessing():
+def install_postprocessing(package_install_option = []):
     ''' Installs the COCO postprocessing as python module. '''
     global RELEASE
     expand_file(join('code-postprocessing', 'setup.py.in'),
                 join('code-postprocessing', 'setup.py'),
                 {'COCO_VERSION': git_version(pep440=True)})
     # copy_tree('code-postprocessing/latex-templates', 'code-postprocessing/cocopp/latex-templates')
-    python('code-postprocessing', ['setup.py', 'install', '--user'], verbose=_verbosity)
+    python('code-postprocessing', ['setup.py', 'install'] + package_install_option, verbose=_verbosity)
 
 def test_suites(args):
     """regression test on suites via Python"""
@@ -279,21 +279,21 @@ def _prep_python():
     #     run('code-experiments/build/python/cython', ['cython', 'interface.pyx'])
 
 
-def build_python(env=None):
+def build_python(env=None, package_install_option = []):
     _prep_python()
     ## Force distutils to use Cython
     # os.environ['USE_CYTHON'] = 'true'
     # python('code-experiments/build/python', ['setup.py', 'sdist'])
     # python(join('code-experiments', 'build', 'python'), ['setup.py', 'install', '--user'])
-    python(join('code-experiments', 'build', 'python'), ['setup.py', 'install', '--user'], env=env)
+    python(join('code-experiments', 'build', 'python'), ['setup.py', 'install'] + package_install_option, env=env)
     # os.environ.pop('USE_CYTHON')
 
 
-def run_python(test=False):
+def run_python(test=False, package_install_option = []):
     """ Builds and installs the Python module `cocoex` and runs the
     `example_experiment.py` as a simple test case. If `test` is True,
     it runs, in addition, the tests in `coco_test.py`."""
-    build_python()
+    build_python(package_install_option = package_install_option)
     try:
         if test:
             python(os.path.join('code-experiments', 'build', 'python'), ['coco_test.py'])
@@ -370,8 +370,8 @@ def test_python(args=(['code-experiments/build/python', ['coco_test.py', 'None']
 
 ################################################################################
 ## Python 2
-def build_python2():
-    build_python(env='python2.7')
+def build_python2(package_install_option = []):
+    build_python(env='python2.7', package_install_option = package_install_option)
 
 
 def test_python2():
@@ -380,8 +380,8 @@ def test_python2():
 
 ################################################################################
 ## Python 3
-def build_python3():
-    build_python(env='python3')
+def build_python3(package_install_option = []):
+    build_python(env='python3', package_install_option = package_install_option)
 
 
 def test_python3():
@@ -706,12 +706,12 @@ def test_java():
 
 ################################################################################
 ## Post processing
-def test_postprocessing(all_tests=False):
-    install_postprocessing()
+def test_postprocessing(all_tests=False, package_install_option = []):
+    install_postprocessing(package_install_option = package_install_option)
     if all_tests:
         try:
             # run example experiment to have a recent data set to postprocess:
-            build_python()
+            build_python(package_install_option = package_install_option)
             python('code-experiments/build/python/', ['-c', '''
 try:
     import example_experiment as ee
@@ -741,41 +741,41 @@ ee.main()  # doctest: +ELLIPSIS
     python('code-postprocessing/aRTAplots', ['generate_aRTA_plot.py'], verbose=_verbosity)
     
 
-def verify_postprocessing():
-    install_postprocessing()
+def verify_postprocessing(package_install_option = []):
+    install_postprocessing(package_install_option = package_install_option)
     # This is not affected by the _verbosity value. Verbose should always be True.
     python('code-postprocessing/cocopp', ['preparehtml.py', '-v'], verbose=True)
 
 
 ################################################################################
 ## Pre-processing
-def install_preprocessing():
+def install_preprocessing(package_install_option = []):
     global RELEASE
     expand_file(join('code-preprocessing/archive-update', 'setup.py.in'),
                 join('code-preprocessing/archive-update', 'setup.py'),
                 {'COCO_VERSION': git_version(pep440=True)})
-    build_python()
+    build_python(package_install_option = package_install_option)
     amalgamate(CORE_FILES + ['code-experiments/src/coco_runtime_c.c'],
                'code-preprocessing/archive-update/interface/coco.c', RELEASE,
                {"COCO_VERSION": git_version(pep440=True)})
     expand_file('code-experiments/src/coco.h', 'code-preprocessing/archive-update/interface/coco.h',
                 {'COCO_VERSION': git_version(pep440=True)})
     python('code-preprocessing/archive-update',
-           ['setup.py', 'install', '--user'], verbose=_verbosity)
+           ['setup.py', 'install'] + package_install_option, verbose=_verbosity)
 
 
-def test_preprocessing():
-    install_preprocessing()
+def test_preprocessing(package_install_option = []):
+    install_preprocessing(package_install_option = package_install_option)
     python('code-preprocessing/archive-update', ['-m', 'pytest'], verbose=_verbosity)
     python('code-preprocessing/log-reconstruction', ['-m', 'pytest'], verbose=_verbosity)
 
 ################################################################################
 ## Global
-def build():
+def build(package_install_option = []):
     builders = [
         build_c,
         # build_matlab,
-        build_python,
+        build_python(package_install_option = package_install_option),
         build_java,
     ]
     for builder in builders:
@@ -790,16 +790,16 @@ def build():
             print("============")
 
 
-def run_all():
+def run_all(package_install_option = []):
     run_c()
     run_java()
-    run_python()
+    run_python(package_install_option = package_install_option)
 
 
-def test():
+def test(package_install_option = []):
     test_c()
     test_java()
-    test_python()
+    test_python(package_install_option = package_install_option)
 
 
 def verbose(args):
@@ -859,27 +859,27 @@ Available commands for users:
   build-matlab            - Build Matlab module
   build-matlab-sms        - Build SMS-EMOA example in Matlab
   build-octave            - Build Matlab module in Octave
-  build-python            - Build Python modules
-  build-python2           - Build Python 2 modules
-  build-python3           - Build Python 3 modules
-  install-postprocessing  - Install postprocessing (user-locally)
+  build-python*           - Build Python modules
+  build-python2*          - Build Python 2 modules
+  build-python3*          - Build Python 3 modules
+  install-postprocessing* - Install postprocessing (user-locally)
 
   run-c                   - Build and run example experiment in C
   run-java                - Build and run example experiment in Java
   run-matlab              - Build and run example experiment in MATLAB
   run-matlab-sms          - Build and run SMS-EMOA on bbob-biobj suite in MATLAB
   run-octave              - Build and run example experiment in Octave
-  run-python              - Build and install COCO module and then run the
+  run-python*             - Build and install COCO module and then run the
                             example experiment in Python. The optional parameter
                             "and-test" also runs the tests of `coco_test.py`
 
 Available commands for developers:
 
-  build                   - Build C, Java and Python modules
-  run                     - Run example experiments in C, Java and Python
+  build*                  - Build C, Java and Python modules
+  run*                    - Run example experiments in C, Java and Python
   silent cmd ...          - Calls "do.py cmd ..." and remains silent if no error occurs
   verbose cmd ...         - Calls "do.py cmd ..." and shows more output
-  test                    - Test C, Java and Python modules
+  test*                   - Test C, Java and Python modules
 
   run-sandbox-python      - Run a Python script with installed COCO module
                             Takes a single argument (name of Python script file)
@@ -894,14 +894,20 @@ Available commands for developers:
   test-python2            - Build and run minimal test of Python 2 module
   test-python3            - Build and run minimal test of Python 3 module
   test-octave             - Build and run example experiment in Octave
-  test-postprocessing     - Runs some of the post-processing tests
-  test-postprocessing-all - Runs all of the post-processing tests [needs access to the internet]
+  test-postprocessing*    - Runs some of the post-processing tests
+  test-postprocessing-all*- Runs all of the post-processing tests [needs access to the internet]
   test-suites             - Runs regression test on all benchmark suites
-  verify-postprocessing   - Checks if the generated html is up-to-date
+  verify-postprocessing*  - Checks if the generated html is up-to-date
   leak-check              - Check for memory leaks in C
   
-  install-preprocessing   - Install preprocessing (user-locally)
-  test-preprocessing      - Runs preprocessing tests [needs access to the internet]
+  install-preprocessing*  - Install preprocessing (user-locally)
+  test-preprocessing*     - Runs preprocessing tests [needs access to the internet]
+  
+The commands marked with an asterisk (*) install Python packages to the global site packages
+directory by default. This behavior can be modified by providing one of the following arguments.
+  
+  install-user            - Installs packages into subdirectories of the user directory
+  install-home=<dir>      - Installs packages into subdirectories of the specified home directory
 
 To build a release version which does not include debugging information in the
 amalgamations set the environment variable COCO_RELEASE to 'true'.
@@ -913,27 +919,35 @@ def main(args):
         help()
         sys.exit(0)
     cmd = args[0].replace('_', '-').lower()
-    if cmd == 'build': build()
-    elif cmd == 'run': run_all()
-    elif cmd == 'test': test()
+    also_test_python = False
+    package_install_option = []
+    for arg in args[1:]:
+        if arg == 'and-test':
+            also_test_python = True
+        elif arg == 'install-user':
+            package_install_option = ['--user']
+        elif arg[:13] == 'install-home=':
+            package_install_option = ['--home=' + arg[13:]]
+    if cmd == 'build': build(package_install_option = package_install_option)
+    elif cmd == 'run': run_all(package_install_option = package_install_option)
+    elif cmd == 'test': test(package_install_option = package_install_option)
     elif cmd == 'build-c': build_c()
     elif cmd == 'build-java': build_java()
     elif cmd == 'build-matlab': build_matlab()
     elif cmd == 'build-matlab-sms': build_matlab_sms()
     elif cmd == 'build-octave': build_octave()
     elif cmd == 'build-octave-sms': build_octave_sms()
-    elif cmd == 'build-python': build_python()
-    elif cmd == 'build-python2': build_python2()
-    elif cmd == 'build-python3': build_python3()
-    elif cmd == 'install-postprocessing': install_postprocessing()
+    elif cmd == 'build-python': build_python(package_install_option = package_install_option)
+    elif cmd == 'build-python2': build_python2(package_install_option = package_install_option)
+    elif cmd == 'build-python3': build_python3(package_install_option = package_install_option)
+    elif cmd == 'install-postprocessing': install_postprocessing(package_install_option = package_install_option)
     elif cmd == 'run-c': run_c()
     elif cmd == 'run-java': run_java()
     elif cmd == 'run-matlab': run_matlab()
     elif cmd == 'run-matlab-sms': run_matlab_sms()
     elif cmd == 'run-octave': run_octave()
     elif cmd == 'run-octave-sms': run_octave_sms()
-    elif cmd == 'run-python':
-        run_python(True) if len(args) > 1 and args[1] == 'and-test' else run_python()
+    elif cmd == 'run-python': run_python(also_test_python, package_install_option = package_install_option)
     elif cmd == 'silent': silent(args[1:])
     elif cmd == 'verbose': verbose(args[1:])
     elif cmd == 'test-c': test_c()
@@ -945,13 +959,13 @@ def main(args):
     elif cmd == 'test-python2': test_python2()
     elif cmd == 'test-python3': test_python3()
     elif cmd == 'test-octave': test_octave()
-    elif cmd == 'test-postprocessing': test_postprocessing()
-    elif cmd == 'test-postprocessing-all': test_postprocessing(True)
+    elif cmd == 'test-postprocessing': test_postprocessing(all_tests = False, package_install_option = package_install_option)
+    elif cmd == 'test-postprocessing-all': test_postprocessing(all_tests = True, package_install_option = package_install_option)
     elif cmd == 'test-suites': test_suites(args[1:])
-    elif cmd == 'verify-postprocessing': verify_postprocessing()
+    elif cmd == 'verify-postprocessing': verify_postprocessing(package_install_option = package_install_option)
     elif cmd == 'leak-check': leak_check()
-    elif cmd == 'install-preprocessing': install_preprocessing()
-    elif cmd == 'test-preprocessing': test_preprocessing()
+    elif cmd == 'install-preprocessing': install_preprocessing(package_install_option = package_install_option)
+    elif cmd == 'test-preprocessing': test_preprocessing(package_install_option = package_install_option)
     else: help()
 
 


### PR DESCRIPTION
We can now pass "install-user" or "install-home=_directory_" as an additional argument to change Python package install location. The default when unspecified is to install to site packages, which works with conda and should work with virtualenv or any other environment manager, I think. The former default was to install to user packages, so to get the exact same behavior as before, we need to pass "install-user" now. I've updated help with relevant usage information and marked the commands that are affected by these new arguments.