### PR TITLE
[WIP] Improve continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,31 +2,31 @@ version: 2
 
 references:
 
-  test_ubuntu_python3: &test_ubuntu_python3
+  install_ubuntu_python2: &install_ubuntu_python2
     run:
-      name: Run tests on Ubuntu with Python 3.
+      name: Install Python 2 on Ubuntu.
       command: |
-        # install dependencies
         apt-get update -qy
-        apt-get install -y build-essential python3-dev python3-numpy python3-matplotlib \
-                           python3-six python3-setuptools python3-scipy
-        # install coco
-        python3 do.py run-python
-        python3 do.py install-postprocessing
-        # run the example
-        cd code-experiments/build/python
-        python3 example_experiment.py bbob
-        # postprocess the results
-        python3 -m cocopp -o ./postproc ./exdata/*
+        apt-get install -y python-dev python-numpy python-matplotlib \
+                           python-six python-setuptools python-scipy \
+                           python-pytest
 
-  test_ubuntu_python2: &test_ubuntu_python2
+  install_ubuntu_python3: &install_ubuntu_python3
     run:
-      name: Run tests on Ubuntu with Python 2.
+      name: Install Python 3 on Ubuntu and set it to be the default.
+      command: |
+        apt-get update -qy
+        apt-get install -y python3-dev python3-numpy python3-matplotlib \
+                           python3-six python3-setuptools python3-scipy \
+                           python3-pytest
+        ln -s /usr/bin/python3 /usr/bin/python  # this is dirty
+
+  test_ubuntu_example: &test_ubuntu_example
+    run:
+      name: Run the random search example on Ubuntu.
       command: |
         # install dependencies
-        apt-get update -qy
-        apt-get install -y build-essential python-dev python-numpy python-matplotlib \
-                           python-six python-setuptools python-scipy
+        apt-get install -y build-essential
         # install coco
         python do.py run-python
         python do.py install-postprocessing
@@ -36,15 +36,37 @@ references:
         # postprocess the results
         python -m cocopp -o ./postproc ./exdata/*
 
-jobs:
+  test_ubuntu_python2: &test_ubuntu_python2
+    run:
+      name: Run Python 2 coco tests on Ubuntu.
+      command: |
+        apt-get install -y git cython
+        python do.py test-python2
 
-  test_ubuntu_latest_python3:
-    docker:
-      - image: ubuntu:latest
-    working_directory: ~/coco
-    steps:
-      - checkout
-      - *test_ubuntu_python3
+  test_ubuntu_python3: &test_ubuntu_python3
+    run:
+      name: Run Python 3 coco tests on Ubuntu.
+      command: |
+        apt-get install -y git cython3
+        python do.py test-python3
+
+  test_ubuntu_other: &test_ubuntu_other
+    run:
+      name: Run all coco tests except for Python on Ubuntu.
+      command: |
+        # install extra dependencies for tests
+        apt-get install -y liboctave-dev openjdk-8-jdk libcmocka-dev \
+                           mlocate texlive-full
+        updatedb
+        # test coco
+        python do.py test-c
+        python do.py test-octave
+        python do.py test-java
+        python do.py test-preprocessing
+        python do.py test-postprocessing-all
+      no_output_timeout: 7200
+
+jobs:
 
   test_ubuntu_rolling_python3:
     docker:
@@ -52,7 +74,10 @@ jobs:
     working_directory: ~/coco
     steps:
       - checkout
+      - *install_ubuntu_python3
+      - *test_ubuntu_example
       - *test_ubuntu_python3
+      - *test_ubuntu_other
 
   test_ubuntu_latest_python2:
     docker:
@@ -60,22 +85,15 @@ jobs:
     working_directory: ~/coco
     steps:
       - checkout
+      - *install_ubuntu_python2
+      - *test_ubuntu_example
       - *test_ubuntu_python2
-
-  test_ubuntu_rolling_python2:
-    docker:
-      - image: ubuntu:rolling
-    working_directory: ~/coco
-    steps:
-      - checkout
-      - *test_ubuntu_python2
+      - *test_ubuntu_other
 
 workflows:
 
   version: 2
   test-matrix:
     jobs:
-      - test_ubuntu_latest_python3
       - test_ubuntu_rolling_python3
       - test_ubuntu_latest_python2
-      - test_ubuntu_rolling_python2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,31 @@ environment:
   matrix:
     - PYTHON_VERSION: 2.7
       MINICONDA: C:\Miniconda
+      CYGWIN: C:\cygwin
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda36
+      CYGWIN: C:\cygwin
 
 init:
   - cmd: "ECHO %PYTHON_VERSION% %MINICONDA%"
   - cmd: "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - cmd: "set PATH=%CYGWIN%;%PATH%"
 
 install:
-  - cmd: conda install -y matplotlib numpy scipy setuptools six
+  - cmd: conda install -y matplotlib numpy scipy setuptools six pytest
   - cmd: python do.py run-python
   - cmd: python do.py install-postprocessing
 
 test_script:
+  # run the experiment
   - cmd: cd code-experiments\build\python
   - cmd: python example_experiment.py bbob
   - cmd: python -m cocopp -o .\postproc .\exdata\random_search_on_bbob_budget0002xD
+  - cmd: cd ..\..\..
+  # run the tests
+  - cmd: python do.py test-c
+  - cmd: python do.py build-python
+  - cmd: python do.py test-python
+  - cmd: python do.py test-java
+  - cmd: python do.py test-preprocessing
+  - cmd: python do.py test-postprocessing-all

--- a/code-postprocessing/cocopp/grayscalesettings.py
+++ b/code-postprocessing/cocopp/grayscalesettings.py
@@ -8,6 +8,7 @@ This module modifies module-defined variables so
 
 """
 
+from __future__ import print_function
 from . import ppfigdim, pprldistr, pplogloss, genericsettings
 from .comp2 import ppscatter, ppfig2, pprldistr2
 from .compall import pprldmany, ppfigs
@@ -26,7 +27,7 @@ def convtograyscale(rgb):
 
     return (rgb[0]*.3 + rgb[1]*.59 + rgb[2]*.11)
 
-print "Using grayscale settings."
+print("Using grayscale settings.")
 
 instancesOfInterest = genericsettings.instancesOfInterest
 

--- a/code-preprocessing/archive-update/python/archive_load_data.py
+++ b/code-preprocessing/archive-update/python/archive_load_data.py
@@ -286,8 +286,8 @@ def get_range(input_set):
        :param input_set: input set with integers (if empty, the result is an empty string)
     """
     result = []
-    for k, g in groupby(enumerate(sorted(input_set)), lambda (i, x): i - x):
-        i_list = map(itemgetter(1), g)
+    for k, g in groupby(enumerate(sorted(input_set)), lambda x: x[0] - x[1]):
+        i_list = list(map(itemgetter(1), g))
         if len(i_list) > 1:
             result.append('{}-{}'.format(i_list[0], i_list[-1]))
         else:

--- a/code-preprocessing/log-reconstruction/test_reconstruction.py
+++ b/code-preprocessing/log-reconstruction/test_reconstruction.py
@@ -83,7 +83,7 @@ def prepare_reconstruction_data(download_data=False):
         for root, dirs, files in walk(data_folder, topdown=False):
             for name in files:
                 # Change file permission so it can be deleted
-                chmod(join(root, name), 0777)
+                chmod(join(root, name), 0o777)
 
 
 def cleanup_reconstruction_data(delete_all=False):


### PR DESCRIPTION
Hi @nikohansen and @brockho. Now that you have a new CI set up, we should make it useful. I suggest to run all the available COCO unit tests. I have already tried to add your unit tests to `.circleci/config.yml` and `appveyor.yml`, however, I struggle to make the tests pass.

1. Windows fails to pass `test-c` with [this error](https://ci.appveyor.com/project/FloopCZ/coco/build/1.0.54/job/4eet7bdrtd4d5r9u) (WindowsError: [Error 2] The system cannot find the file specified). I am not sure what file is it missing, maybe there is something more that has to be done before running `test-c`? @brockho will probably know more.
2. Ubuntu Python 2 fails to pass postprocessing tests with [this error](https://circleci.com/gh/FloopCZ/coco/176) (Test failed: error while running bibtex on templateBBOBarticle.). I may be missing some special latex dependency installed, but I have no Idea which one.
3. Ubuntu Python 3 fails to pass some preprocessing or postprocessing tests with [this error](https://circleci.com/gh/FloopCZ/coco/177) (ImportError: No module named setuptools). This one may be caused by the fact that somewhere in the preprocessing/postprocessing code, python 2 is hardcoded (instead of using the python interpreter, which is used to run the main script). I suppose that this error does not appear in Jenkins and your personal computers, since they have both Python 2 and 3 installed. However, in the CircleCI environment, I have deliberately installed only the Python that is really tested.

If you are interested, please push some more edits to `.circleci/config.yml` and `appveyor.yml` into this branch to make it pass all the tests. You have the permission to push into it. I believe that you are more experienced with your own unit tests.

P.S.: I had to put in a few more Python 2 to Python 3 conversions to make the tests compile under Python 3, but nothing serious.