### PR TITLE
Reset foreground algorithm list if cocopp.main() is called.

### DIFF
--- a/code-postprocessing/cocopp/rungeneric.py
+++ b/code-postprocessing/cocopp/rungeneric.py
@@ -267,6 +267,11 @@ def main(argv=None):
                 dsld = rungeneric1.main(genopts + ["-o", outputdir, alg])
 
         if len(args) >= 2 or len(genericsettings.background) > 0:
+            # Reset foreground algorithm list if cocopp.main() is called.
+            # Otherwise the list accumulates arguments passed to cocopp.main().
+            # Arguments are still accumulated if rungeneric.main() is bypassed
+            # and rungenericmany.main() or lower-level functions are called.
+            genericsettings.foreground_algorithm_list = []
             dsld = rungenericmany.main(genopts + ["-o", outputdir] + args)
             toolsdivers.prepend_to_file(latex_commands_filename,
                                         ['\\providecommand{\\numofalgs}{2+}']


### PR DESCRIPTION
The issue itself is resolved. Still prints out that foreground algorithm list is changed from empty set to whatever, though. See second last line in the output below. Should read `foreground_algorithm_list: from ['.\\CMAES', '.\\DEAE'] to ['.\\CMAES', '.\\JADE']`, in my opinion. If that's any concern, we can open an issue for it, I think.

```
In [2]: import cocopp

In [3]: cocopp.main("CMAES DEAE")

Post-processing (2+): will generate output data in folder ppdata
  this might take several minutes.
  Data consistent according to consistency_check() in pproc.DataSet
  using: .\CMAES
  Data consistent according to consistency_check() in pproc.DataSet
  using: .\DEAE
ECDF runlength ratio graphs...
C:\Users\randopt\AppData\Roaming\Python\Python27\site-packages\cocopp-2.0.528-py2.7.egg\cocopp\comp2\pprldistr2.py:146: RuntimeWarning: invalid value encountered in divide
  x.append((tmp1/tmp0).flatten())  # inf/inf results in nan
  done (Mon Aug 28 16:32:38 2017).
ECDF runlength graphs...
  done (Mon Aug 28 16:32:51 2017).
ECDF graphs per noise group...
Loading best algorithm data from refalgs/best2009-bbob.tar.gz ...
  Data consistent according to consistency_check() in pproc.DataSet
  using: C:\Users\randopt\AppData\Roaming\Python\Python27\site-packages\cocopp-2.0.528-py2.7.egg\cocopp\refalgs/best2009-bbob.tar.gz
  done (Mon Aug 28 16:32:52 2017).
  done (Mon Aug 28 16:32:55 2017).
ECDF graphs per function group...
  done (Mon Aug 28 16:33:06 2017).
ECDF graphs per function...
  done (Mon Aug 28 16:33:50 2017).
Generating comparison tables...
  done (Mon Aug 28 16:33:52 2017).
Scatter plots...
  done (Mon Aug 28 16:34:09 2017).
Scaling figures...
  done (Mon Aug 28 16:34:24 2017).
Changed settings in `genericsettings` (compared to default):
    foreground_algorithm_list: from [] to ['.\\CMAES', '.\\DEAE']
ALL done (Mon Aug 28 16:34:24 2017).

In [4]: cocopp.main("CMAES JADE")

Post-processing (2+): will generate output data in folder ppdata
  this might take several minutes.
  Data consistent according to consistency_check() in pproc.DataSet
  using: .\CMAES
  Data consistent according to consistency_check() in pproc.DataSet
  using: .\JADE
ECDF runlength ratio graphs...
  done (Mon Aug 28 16:34:49 2017).
ECDF runlength graphs...
  done (Mon Aug 28 16:35:01 2017).
ECDF graphs per noise group...
  done (Mon Aug 28 16:35:05 2017).
ECDF graphs per function group...
  done (Mon Aug 28 16:35:15 2017).
ECDF graphs per function...
  done (Mon Aug 28 16:36:00 2017).
Generating comparison tables...
  done (Mon Aug 28 16:36:01 2017).
Scatter plots...
  done (Mon Aug 28 16:36:17 2017).
Scaling figures...
  done (Mon Aug 28 16:36:32 2017).
Changed settings in `genericsettings` (compared to default):
    foreground_algorithm_list: from [] to ['.\\CMAES', '.\\JADE']
ALL done (Mon Aug 28 16:36:32 2017).```