### PR TITLE
solves #1523

### DIFF
--- a/code-postprocessing/cocopp/__init__.py
+++ b/code-postprocessing/cocopp/__init__.py
@@ -29,6 +29,7 @@ del matplotlib
 from numpy.random import seed as set_seed
 
 from .cococommands import *
+from . import config
 
 from .rungeneric import main as main
 

--- a/code-postprocessing/cocopp/bestalg.py
+++ b/code-postprocessing/cocopp/bestalg.py
@@ -481,6 +481,7 @@ def deprecated_customgenerate(args=algs2009):
 
     >>> from cocopp import bestalg
     >>> import os
+    >>> returnpath = os.getcwd()  # needed for no effect on other doctests 
     >>> path = os.path.abspath(os.path.dirname('__file__'))
     >>> os.chdir(os.path.join(path, 'data'))
     >>> infoFile = 'ALPS/bbobexp_f2.info'
@@ -494,7 +495,7 @@ def deprecated_customgenerate(args=algs2009):
     >>> os.chdir(os.path.join(path, 'data'))
     >>> bestalg.custom_generate(('ALPS', ''), 'refAlgFromALPS') # doctest: +ELLIPSIS
     Searching in...
-    >>> os.chdir(path)
+    >>> os.chdir(returnpath)
 
     """
 
@@ -662,6 +663,7 @@ def getAllContributingAlgorithmsToBest(algnamelist, target_lb=1e-8,
         >>> from cocopp import bestalg
         >>> import os
         >>> import urllib
+        >>> returnpath = os.getcwd()  # needed for no effect on other doctests
         >>> path = os.path.abspath(os.path.dirname(os.path.dirname('__file__')))
         >>> os.chdir(path)
         >>> infoFile = 'data/BIPOP-CMA-ES.tgz'
@@ -678,6 +680,7 @@ def getAllContributingAlgorithmsToBest(algnamelist, target_lb=1e-8,
         >>> os.chdir(path)
         >>> bestalg.getAllContributingAlgorithmsToBest(('data/BIPOP-CMA-ES.tgz', 'data/MCS.tgz')) # doctest:+ELLIPSIS
         Generating best algorithm data...
+        >>> os.chdir(returnpath)
 
     """
 

--- a/code-postprocessing/cocopp/cococommands.py
+++ b/code-postprocessing/cocopp/cococommands.py
@@ -20,6 +20,7 @@ Examples:
     >>> import os
     >>> import urllib
     >>> import tarfile
+    >>> returnpath = os.getcwd()  # needed for no effect on other doctests
     >>> path = os.path.abspath(os.path.dirname(os.path.dirname('__file__')))
     >>> os.chdir(path)
     >>> pp.genericsettings.verbose = False # ensure to make below doctests work 
@@ -47,6 +48,7 @@ Examples:
     1 Function with ID 2
     Dimension(s): 2, 3, 5, 10, 20, 40
     Max evals: [762, 1537, 2428, 6346, 20678, 75010]
+    >>> os.chdir(returnpath)  # no effect on path from this doctest
 
 """
 

--- a/code-postprocessing/cocopp/ppfig.py
+++ b/code-postprocessing/cocopp/ppfig.py
@@ -563,12 +563,14 @@ def consecutiveNumbers(data, prefix=''):
 
     Example::
       >>> import os
+      >>> returnpath = os.getcwd()  # needed for no effect on other doctests
       >>> os.chdir(os.path.abspath(os.path.dirname(os.path.dirname('__file__'))))
       >>> import cocopp as bb
       >>> bb.ppfig.consecutiveNumbers([0, 1, 2, 4, 5, 7, 8, 9])
       '0-2, 4, 5, 7-9'
       >>> bb.ppfig.consecutiveNumbers([0, 1, 2, 4, 5, 7, 8, 9], 'f')
       'f0-f2, f4, f5, f7-f9'
+      >>> os.chdir(returnpath)  # no effect on path from this doctest
 
     Range of consecutive numbers is at least 3 (therefore [4, 5] is
     represented as "4, 5").

--- a/code-postprocessing/cocopp/pproc.py
+++ b/code-postprocessing/cocopp/pproc.py
@@ -300,7 +300,7 @@ class RunlengthBasedTargetValues(TargetValues):
             self._short_info = 'reference budgets from ' + self.reference_algorithm
 
             from . import bestalg
-            self.reference_data = bestalg.load_reference_algorithm(self.reference_algorithm, force=True)
+            self.reference_data = bestalg.load_reference_algorithm(self.reference_algorithm, force=True, relative_load=False)
             # TODO: remove targets smaller than 1e-8
         elif type(self.reference_data) is str:  # self.reference_data in ('RANDOMSEARCH', 'IPOP-CMA-ES') should work
             self._short_info = 'reference budgets from ' + self.reference_data
@@ -552,6 +552,7 @@ class DataSet(object):
         >>> import os
         >>> import urllib
         >>> import tarfile
+        >>> returnpath = os.getcwd() # needed for no effect to other doctests
         >>> path = os.path.abspath(os.path.dirname(os.path.dirname('__file__')))
         >>> os.chdir(path)
         >>> import cocopp as bb
@@ -729,6 +730,8 @@ class DataSet(object):
         >>> # set things back to cause no troubles elsewhere:
         >>> bb.testbedsettings.GECCOBBOBTestbed.settings['instancesOfInterest'] = None
         >>> bb.config.config('GECCOBBOBTestbed') # make sure that settings are used
+        
+        >>> os.chdir(returnpath) # return to folder before doctest
 
     """
 


### PR DESCRIPTION
In order to do so, I
   * added `from . import config` in `__init__.py`
   * added `relative_load=False` when reference algorithm is loaded in `pproc.py`
In addition, I cleaned up paths in doctests wherever `os.chdir` is used (needs to be made nicer, i.e. by removing usage of `os.chdir` as much as possible).