### PR TITLE
solving issue #1658

### DIFF
--- a/code-postprocessing/cocopp/compall/pptables.py
+++ b/code-postprocessing/cocopp/compall/pptables.py
@@ -515,8 +515,9 @@ def main(dict_alg, sorted_algs, output_dir='.', function_targets_line=True, late
             # data, dispersion, isBoldArray, isItalArray, nbsucc, nbruns, testres):
             command_name = r'\alg%stables' % numtotext(i)
             #            header += r'\providecommand{%s}{{%s}{}}' % (command_name, str_to_latex(strip_pathname(alg)))
-            additional_commands.append('\\providecommand{%s}{\\StrLeft{%s}{\\ntables}}' %
-                                       (command_name, str_to_latex(strip_pathname1(alg))))
+            if df[0] == genericsettings.tabDimsOfInterest[0]:
+                additional_commands.append('\\providecommand{%s}{\\StrLeft{%s}{\\ntables}}' %
+                                           (command_name, str_to_latex(strip_pathname1(alg))))
             curline = [command_name + r'\hspace*{\fill}']  # each list element becomes a &-separated table entry?
             curlineHtml = ['<th>%s</th>\n' % str_to_latex(strip_pathname1(alg))]
 
@@ -703,7 +704,7 @@ def main(dict_alg, sorted_algs, output_dir='.', function_targets_line=True, late
     if len(additional_commands) > 0:
         for command in additional_commands:
             prepend_to_file(latex_commands_file, [command])
-    if len(tables_header) > 0:
+    if len(tables_header) > 0 and df[0] == genericsettings.tabDimsOfInterest[0]:
         extraeol = [r'\hline']
         res = tableXLaTeX([tables_header], spec=spec, extra_eol=extraeol, add_end_tabular=False)
         prepend_to_file(latex_commands_file, ['\\providecommand{\\pptablesheader}{', res, '}'])


### PR DESCRIPTION
...by not writing the LaTeX commands with every dimension (40-D came first in `cocopp_commands.tex` after we introduced the sorting of the dimension; this caused the bug when less algorithms have data in 40-D than in the other dimensions).