### PR TITLE
small format adjustment addressing #1689

### DIFF
--- a/code-postprocessing/cocopp/pptable.py
+++ b/code-postprocessing/cocopp/pptable.py
@@ -293,8 +293,8 @@ def main(dsList, dims_of_interest, outputdir, latex_commands_file):
                     tableentryHtml = writeFEvalsMaxPrec(tmp, 2)
 
                     if np.isinf(tmp) and i == len(data)-1:
-                        tableentry = (tableentry + r'\textit{%s}' % writeFEvals2(np.median(entry.maxevals), 2))
-                        tableentryHtml = (tableentryHtml + ' <i>%s</i>' % writeFEvals2(np.median(entry.maxevals), 2))
+                        tableentry = (tableentry + r'\textit{%s}' % writeFEvals2(np.median(entry.maxevals), 2, 3))
+                        tableentryHtml = (tableentryHtml + ' <i>%s</i>' % writeFEvals2(np.median(entry.maxevals), 2, 3))
                         if is_bold:
                             tableentry = r'\textbf{%s}' % tableentry
                             tableentryHtml = '<b>%s</b>' % tableentryHtml

--- a/code-postprocessing/cocopp/pptable.py
+++ b/code-postprocessing/cocopp/pptable.py
@@ -293,8 +293,8 @@ def main(dsList, dims_of_interest, outputdir, latex_commands_file):
                     tableentryHtml = writeFEvalsMaxPrec(tmp, 2)
 
                     if np.isinf(tmp) and i == len(data)-1:
-                        tableentry = (tableentry + r'\textit{%s}' % writeFEvals2(np.median(entry.maxevals), 2, 3))
-                        tableentryHtml = (tableentryHtml + ' <i>%s</i>' % writeFEvals2(np.median(entry.maxevals), 2, 3))
+                        tableentry = (tableentry + r'\textit{%s}' % writeFEvals2(np.median(entry.maxevals).astype(int), 2, 3))
+                        tableentryHtml = (tableentryHtml + ' <i>%s</i>' % writeFEvals2(np.median(entry.maxevals).astype(int), 2, 4))
                         if is_bold:
                             tableentry = r'\textbf{%s}' % tableentry
                             tableentryHtml = '<b>%s</b>' % tableentryHtml


### PR DESCRIPTION
Now the maximal width is defined as 3 chars, which cancels the precision prescription. The latter lead to irritating rounding results as shown in #1689