### PR TITLE
added the `, 'bbob'` in line 346 of `do.py` as suggested in issue…

### DIFF
--- a/do.py
+++ b/do.py
@@ -343,7 +343,7 @@ def run_python(test=False, package_install_option = []):
         if test:
             python(os.path.join('code-experiments', 'build', 'python'), ['coco_test.py'])
         python(os.path.join('code-experiments', 'build', 'python'),
-               ['example_experiment.py'])
+               ['example_experiment.py', 'bbob'])
     except subprocess.CalledProcessError:
         sys.exit(-1)
 


### PR DESCRIPTION
…#1698 directly, bypassing the conflicts of pull request #1701 

@nikohansen , would you be so kind and accept the pull request? All Jenkins tests went through (although they appear still as pending here on github) and the errors on CircleCI and Appveyor are due to the yet unfixed issue #1703 (for which the fix is already proposed in pull request #1704).