### PR TITLE
change java path search + java 10 support 

### DIFF
--- a/code-experiments/tools/cocoutils.py
+++ b/code-experiments/tools/cocoutils.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 import sys
 import os
+from distutils.spawn import find_executable
 from shutil import copyfile, copytree, rmtree
 from subprocess import CalledProcessError, call, STDOUT
 
@@ -225,3 +226,10 @@ def expand_file(source, destination, dictionary):
         content = Template(fd.read())
         with open(destination, "w") as outfd:
             outfd.write(content.safe_substitute(dictionary))
+
+
+def executable_path(name):
+    p = find_executable(name)
+    if p:
+        return os.path.realpath(p)
+

--- a/do.py
+++ b/do.py
@@ -692,7 +692,7 @@ def build_java():
             if not javapath:
                 raise RuntimeError('Can not find Java executable')
             jdkhome = abspath(join(javapath, os.pardir, os.pardir))
-            if os.path.dirname(jdkhome) == 'jre':
+            if os.path.basename(jdkhome) == 'jre':
                 jdkhome = join(jdkhome, os.pardir)
 
         jdkpath1 = join(jdkhome, 'include')

--- a/do.py
+++ b/do.py
@@ -686,7 +686,7 @@ def build_java():
         #                       env=os.environ, universal_newlines=True)
         #jdkpath1 = jdkpath.split("jni.h")[0]
         # better
-        jdkhome = os.environ['JAVA_HOME'] or os.environ['JDK_HOME']
+        jdkhome = os.environ.get('JAVA_HOME') or os.environ.get('JDK_HOME')
         if not jdkhome:
             javapath = executable_path('java')
             if not javapath:

--- a/do.py
+++ b/do.py
@@ -686,10 +686,16 @@ def build_java():
         #                       env=os.environ, universal_newlines=True)
         #jdkpath1 = jdkpath.split("jni.h")[0]
         # better
-        javapath = executable_path('java')
-        if not javapath:
-            raise RuntimeError('Can not find Java executable')
-        jdkpath1 = abspath(join(javapath, os.pardir, os.pardir, 'include'))
+        jdkhome = os.environ['JAVA_HOME'] or os.environ['JDK_HOME']
+        if not jdkhome:
+            javapath = executable_path('java')
+            if not javapath:
+                raise RuntimeError('Can not find Java executable')
+            jdkhome = abspath(join(javapath, os.pardir, os.pardir))
+            if os.path.dirname(jdkhome) == 'jre':
+                jdkhome = join(jdkhome, os.pardir)
+
+        jdkpath1 = join(jdkhome, 'include')
         jdkpath2 = jdkpath1 + '/linux'
         run('code-experiments/build/java',
             ['gcc', '-I', jdkpath1, '-I', jdkpath2, '-c', 'CocoJNI.c'],


### PR DESCRIPTION
Hi

I think that it's a bad idea to use  `locate` in `do.py` to search for `jni.h` header file
* it requires `locate`
* can find the wrong file (happened to me)

If we search for a  `java` binary we can find `jre` or `jdk` directory and then get to the `include` folder.

Also in java 10 there is no `javah` binary, only `javac` with flag `-h`.  
