### PR TITLE
Kostas ls removing coco random new

### DIFF
--- a/code-experiments/src/transform_vars_blockrotation_helpers.c
+++ b/code-experiments/src/transform_vars_blockrotation_helpers.c
@@ -106,7 +106,7 @@ static void coco_compute_blockrotation(double **B, long seed, size_t n, size_t *
     current_block = bbob2009_allocate_matrix(current_blocksize, current_blocksize);
     current_nb_entries = current_blocksize * current_blocksize;
     tmp_normal = coco_allocate_vector(current_nb_entries);
-    bbob2009_gauss(tmp_normal, current_nb_entries, seed + (long) 1000000 * (long) idx_block);/* TODO: To be discussed */
+    bbob2009_gauss(tmp_normal, current_nb_entries, seed + (long) 1000000 * (long) current_blocksize);/* TODO: To be discussed */
 
     for (i = 0; i < current_blocksize; i++) {
       for (j = 0; j < current_blocksize; j++) {


### PR DESCRIPTION
It removes the usage of `coco_random.c` for the random permutations, for the block rotations as well as for the definition of the Gallagher and Lunacek Bi-Rastrigin functions. 