### PR TITLE
Silence matplotlib 3.3.2 warning

### DIFF
--- a/code-postprocessing/cocopp/comp2/pprldistr2.py
+++ b/code-postprocessing/cocopp/comp2/pprldistr2.py
@@ -78,8 +78,8 @@ def beautify(handles):
     toolsdivers.legend(loc='best')
 
     x = numpy.asarray(axisHandle.get_xticks())
-    axisHandle.set_xticklabels([str(int(numpy.log10(xx))) for xx in x])
     axisHandle.set_xticks(x)
+    axisHandle.set_xticklabels([str(int(numpy.log10(xx))) for xx in x])
     plt.xlim(xlim)
 
 


### PR DESCRIPTION
UserWarning: FixedFormatter should only be used together with FixedLocator

by setting the xticks before their labels.