### PR TITLE
x-limits in plots to be exposed in genericsettings Issue: 1662

### DIFF
--- a/code-postprocessing/cocopp/compall/pprldmany.py
+++ b/code-postprocessing/cocopp/compall/pprldmany.py
@@ -46,8 +46,7 @@ from .. import pptex  # numtotex
 PlotType = ppfig.enum('ALG', 'DIM', 'FUNC')
 
 displaybest = True
-x_limit = None  # not sure whether this is necessary/useful
-x_limit_default = 1e7  # better: 10 * genericsettings.evaluation_setting[1], noisy: 1e8, otherwise: 1e7. maximal run length shown
+x_limit = genericsettings.x_limit_pprldmany
 divide_by_dimension = True
 annotation_line_end_relative = 1.11  # lines between graph and annotation
 annotation_space_end_relative = 1.24  # figure space end relative to x_limit
@@ -567,10 +566,8 @@ def main(dictAlg, order=None, outputdir='.', info='default',
     :param str parentHtmlFileName: defines the parent html page 
 
     """
-    global x_limit  # late assignment of default, because it can be set to None in config 
+    global x_limit  
     global divide_by_dimension  # not fully implemented/tested yet
-    if 'x_limit' not in globals() or x_limit is None:
-        x_limit = x_limit_default
 
     tmp = pp.dictAlgByDim(dictAlg)
     algorithms_with_data = [a for a in dictAlg.keys() if dictAlg[a] != []]

--- a/code-postprocessing/cocopp/genericsettings.py
+++ b/code-postprocessing/cocopp/genericsettings.py
@@ -316,3 +316,4 @@ isPickled = False  # only affects rungeneric1
 ##    
 isScatter = True  # only affects rungenericmany
 
+x_limit_pprldmany = 1e7  # better: 10 * genericsettings.evaluation_setting[1], noisy: 1e8, otherwise: 1e7. maximal run length shown


### PR DESCRIPTION
Description:
The x-limits for the ECDF plots were hard-coded to 1e7. We expose cocopp.compall.pprldmany.x_limit to cocopp.genericsettings as it is done already for the expensive setting.

Testing: 
I am not sure how to test that it works.
