### PR TITLE
New features in the constrained test suite

### DIFF
--- a/code-experiments/build/python/cython/interface.pyx
+++ b/code-experiments/build/python/cython/interface.pyx
@@ -7,10 +7,11 @@ cimport numpy as np
 
 from cocoex.exceptions import InvalidProblemException, NoSuchProblemException, NoSuchSuiteException
 
-known_suite_names = ["bbob", "bbob-biobj", "bbob-largescale", "bbob-biobj-ext",
-                     "bbob-mixint", "bbob-biobj-mixint"]
-_known_suite_names = ["bbob", "bbob-biobj", "bbob-biobj-ext", "bbob-constrained", "bbob-largescale",
-                     "bbob-mixint", "bbob-biobj-mixint"]
+
+known_suite_names = ["bbob", "bbob-biobj", "bbob-biobj-ext", "bbob-largescale",
+                     "bbob-constrained", "bbob-mixint", "bbob-biobj-mixint"]
+_known_suite_names = ["bbob", "bbob-biobj", "bbob-biobj-ext", "bbob-largescale",
+                      "bbob-constrained", "bbob-mixint", "bbob-biobj-mixint"]
 
 
 # _test_assignment = "seems to prevent an 'export' error (i.e. induce export) to make this module known under Linux and Windows (possibly because of the leading underscore of _interface)"

--- a/code-experiments/src/c_linear.c
+++ b/code-experiments/src/c_linear.c
@@ -18,6 +18,8 @@
 typedef struct {
   double *gradient;
   double *x;
+  double x_shift_factor; /* shift solution by - factor * gradient */
+  double gradient_norm;
 } linear_constraint_data_t;	
 
 static void c_sum_variables_evaluate(coco_problem_t *self, 
@@ -36,7 +38,8 @@ static void c_linear_gradient_free(void *thing);
 static coco_problem_t *c_sum_variables_allocate(const size_t number_of_variables);
 
 static coco_problem_t *c_linear_transform(coco_problem_t *inner_problem, 
-                                          const double *gradient);
+                                          const double *gradient,
+                                          const double x_shift_factor);
          
 static coco_problem_t *c_linear_single_cons_bbob_problem_allocate(const size_t function,
                                                       const size_t dimension,
@@ -46,12 +49,13 @@ static coco_problem_t *c_linear_single_cons_bbob_problem_allocate(const size_t f
                                                       const char *problem_id_template,
                                                       const char *problem_name_template,
                                                       double *gradient,
+                                                      double x_shift_factor,
                                                       const double *feasible_direction);
                                                       
 static coco_problem_t *c_linear_cons_bbob_problem_allocate(const size_t function,
                                                       const size_t dimension,
                                                       const size_t instance,
-                                                      const size_t number_of_linear_constraints,
+                                                      const size_t number_of_active_constraints,
                                                       const char *problem_id_template,
                                                       const char *problem_name_template,
                                                       const double *feasible_direction);
@@ -82,6 +86,7 @@ static void c_linear_single_evaluate(coco_problem_t *self,
                                      double *y) {
 	
   size_t i;
+  double factor;
   
   linear_constraint_data_t *data;
   coco_problem_t *inner_problem;
@@ -90,9 +95,10 @@ static void c_linear_single_evaluate(coco_problem_t *self,
   inner_problem = coco_problem_transformed_get_inner_problem(self);
   
   assert(self->number_of_constraints == 1);
-			
-  for (i = 0; i < self->number_of_variables; ++i)
-    data->x[i] = (data->gradient[i])*x[i];
+
+  for (i = 0, factor = data->x_shift_factor / data->gradient_norm;
+       i < self->number_of_variables; ++i)
+    data->x[i] = (data->gradient[i]) * (x[i] - factor * data->gradient[i]);
   
   coco_evaluate_constraint(inner_problem, data->x, y);
   
@@ -167,16 +173,25 @@ static coco_problem_t *c_sum_variables_allocate(const size_t number_of_variables
 /**
  * @brief Transforms a linear constraint with all-ones gradient
  *        into a linear constraint whose gradient is passed 
- *        as argument.
+ *        as argument and with the feasible domain extended by
+ *        shift_factor.
  */
 static coco_problem_t *c_linear_transform(coco_problem_t *inner_problem, 
-                                          const double *gradient) {
+                                          const double *gradient,
+                                          const double shift_factor) {
   
   linear_constraint_data_t *data;
   coco_problem_t *self;
+  double gradient_norm = coco_vector_norm(gradient, inner_problem->number_of_variables);
+
+  if (gradient_norm <= 0)
+    coco_error("c_linear_transform(): gradient norm %f<=0 zero", gradient_norm);
+
   data = coco_allocate_memory(sizeof(*data));
   data->gradient = coco_duplicate_vector(gradient, inner_problem->number_of_variables);
   data->x = coco_allocate_vector(inner_problem->number_of_variables);
+  data->x_shift_factor = shift_factor;
+  data->gradient_norm = gradient_norm;
   self = coco_problem_transformed_allocate(inner_problem, data, 
       c_linear_gradient_free, "gradient_linear_constraint");
   self->evaluate_constraint = c_linear_single_evaluate;
@@ -200,6 +215,7 @@ static coco_problem_t *c_linear_single_cons_bbob_problem_allocate(const size_t f
                                                       const char *problem_id_template,
                                                       const char *problem_name_template,
                                                       double *gradient,
+                                                      const double x_shift_factor,
                                                       const double *feasible_direction) {
 																			
   size_t i;
@@ -238,7 +254,7 @@ static coco_problem_t *c_linear_single_cons_bbob_problem_allocate(const size_t f
     coco_vector_scale(gradient, dimension,
                       factor1 * factor2,
                       coco_vector_norm(gradient, dimension));
-    problem = c_linear_transform(problem, gradient);
+    problem = c_linear_transform(problem, gradient, x_shift_factor);
 
   }
   else{ /* Randomly generate the gradient of the linear constraint */
@@ -252,7 +268,7 @@ static coco_problem_t *c_linear_single_cons_bbob_problem_allocate(const size_t f
       gradient_linear_constraint[i] = factor1 *
                 coco_random_normal(random_generator) * factor2 / sqrt((double)dimension);
 
-    problem = c_linear_transform(problem, gradient_linear_constraint);
+    problem = c_linear_transform(problem, gradient_linear_constraint, x_shift_factor);
     coco_free_memory(gradient_linear_constraint);
   }
   
@@ -274,6 +290,33 @@ static coco_problem_t *c_linear_single_cons_bbob_problem_allocate(const size_t f
 }
 
 /**
+ * @brief helper function to successively compute a linear combination of
+ *        constraint gradients, add current gradient if weight is != 0.
+ *
+*/
+static void con_update_linear_combination(double *linear_combination,
+                                          const coco_problem_t *problem,
+                                          double weight) {
+  size_t i;
+  linear_constraint_data_t *data;
+
+  data = (linear_constraint_data_t *) coco_problem_transformed_get_data(problem);
+  if (data->gradient == NULL) {
+    if (weight != 0) coco_error("con_update_linear_combination(): gradient of constraint was zero");
+    else coco_warning("con_update_linear_combination(): gradient of constraint was zero");
+  }
+  if (data->x_shift_factor != 0)
+    coco_warning("Inactive constraint passed to update_linear_combination, x_shift_factor=%f",
+                 data->x_shift_factor);
+  if (weight == 0)
+    return; /* nothing to add */
+  if (weight < 0)
+    coco_warning("con_update_linear_combination: weight=%f < 0, should be > 0", weight);
+  for (i = 0; i < problem->number_of_variables; ++i)
+    linear_combination[i] += weight * data->gradient[i];
+}
+
+/**
  * @brief Builds a coco_problem_t containing all the linear constraints
  *        by stacking them all.
  * 
@@ -292,30 +335,46 @@ static coco_problem_t *c_linear_single_cons_bbob_problem_allocate(const size_t f
 static coco_problem_t *c_linear_cons_bbob_problem_allocate(const size_t function,
                                                       const size_t dimension,
                                                       const size_t instance,
-                                                      const size_t number_of_linear_constraints,
+                                                      const size_t number_of_active_constraints,
                                                       const char *problem_id_template,
                                                       const char *problem_name_template,
                                                       const double *feasible_direction) {
 																																			
   const double global_scaling_factor = 100.;
-  size_t i;
+  size_t i, j;
   
   coco_problem_t *problem_c = NULL;
   coco_problem_t *problem_c2 = NULL;
   coco_random_state_t *random_generator;
+  coco_random_state_t *random_generator2;
   double *gradient_c1 = NULL;
   double *gradient;
+  double *linear_combination;
+  linear_constraint_data_t *first_constraint_data = NULL;
+  double shift_factor;
   long seed_cons;
-  double exp1, factor1;
-  
+  double fac, norm, factor1;
+  size_t number_of_linear_constraints;
+  size_t inactive_constraints_left = number_of_active_constraints / 2;  /* TODO: decide whether this should go into the interface */
+  int disguise_gradient = 1;
+
+  if (strncmp(problem_id_template, "bbob-constrained-active-only", 28) == 0)
+    inactive_constraints_left = 0;
+
+  if (strncmp(problem_id_template, "bbob-constrained-no-disguise", 28) == 0)
+    disguise_gradient = 0;
+
+  number_of_linear_constraints = number_of_active_constraints + inactive_constraints_left;
+
   gradient_c1 = coco_allocate_vector(dimension);
+  linear_combination = coco_allocate_vector_with_value(dimension, 0.0);
   																	
   for (i = 0; i < dimension; ++i)
     gradient_c1[i] = -feasible_direction[i];
 
   /* Build a coco_problem_t object for each constraint. 
    * The constraints' gradients are generated randomly with
-   * distriution 10**U[0,1] * N_i(0, I) * 10**U_i[0,2]
+   * distribution 10**U[0,1] * N_i(0, I/n) * 10**U_i[0,2]
    * where U[a, b] is uniform in [a,b] and only U_i is drawn 
    * for each constraint individually.
    */
@@ -323,35 +382,61 @@ static coco_problem_t *c_linear_cons_bbob_problem_allocate(const size_t function
   /* Calculate the first random factor 10**U[0,1]. */
   seed_cons = (long)(function + 10000 * instance);
   random_generator = coco_random_new((uint32_t) seed_cons);
-  exp1 = coco_random_uniform(random_generator);
-  factor1 = global_scaling_factor * pow(10.0, exp1);
+  random_generator2 = coco_random_new((uint32_t) seed_cons);
+  factor1 = global_scaling_factor * pow(10.0, coco_random_uniform(random_generator));
 
   /* Build the first linear constraint using 'gradient_c1' to build
    * its gradient.
    */ 
   /* set gradient depending on instance number */
-  gradient = instance % number_of_linear_constraints ? NULL : gradient_c1;
+  gradient = instance % number_of_active_constraints ? NULL : gradient_c1;
   problem_c = c_linear_single_cons_bbob_problem_allocate(function,
       dimension, instance, 1, factor1,
-      problem_id_template, problem_name_template, gradient,
+      problem_id_template, problem_name_template, gradient, 0.0,
       feasible_direction);
+  if (gradient != NULL)  /* preserve the constraint based on function gradient */
+    first_constraint_data = (linear_constraint_data_t *) coco_problem_transformed_get_data(problem_c);
+  else
+    con_update_linear_combination(linear_combination, problem_c,
+                                  coco_random_uniform(random_generator2));
 	 
   /* Instantiate the other linear constraints (if any) and stack them 
    * all into problem_c
-   */     
-  for (i = 2; i <= number_of_linear_constraints; ++i) {
+   */
+  for (j = 2, i = 1; j <= number_of_linear_constraints; ++j) {
 	 
     /* Instantiate a new problem containing one linear constraint only */
     /* set gradient depending on instance number */
-    gradient = (i - 1 + instance) % number_of_linear_constraints ? NULL : gradient_c1;
-    problem_c2 = c_linear_single_cons_bbob_problem_allocate(function,
-        dimension, instance, i, factor1,
-        problem_id_template, problem_name_template, gradient,
+
+    if (i < number_of_active_constraints && coco_random_uniform(random_generator)
+          + 1e-23 > (double) inactive_constraints_left / (double) number_of_linear_constraints
+        ) {  /* create an active constraint */
+      gradient = (++i - 1 + instance) % number_of_active_constraints ? NULL : gradient_c1;
+      shift_factor = 0.0;
+    } else {  /* create an inactive (shifted) constraint */
+      if (inactive_constraints_left-- <= 0)
+        coco_error("c_linear_cons_bbob_problem_allocate(): no inactive left i=%d j=%d nb_act=%ul nb_con=%ul",
+                   i, j, number_of_active_constraints, number_of_linear_constraints);
+      gradient = NULL;
+      shift_factor = 0.01 + 2.0 * coco_random_uniform(random_generator);
+    }
+
+    problem_c2 = c_linear_single_cons_bbob_problem_allocate(function, dimension, instance,
+        i <= number_of_active_constraints ? i : number_of_linear_constraints - inactive_constraints_left,
+        factor1, problem_id_template, problem_name_template, gradient, shift_factor,
         feasible_direction);
-		
+    if (shift_factor == 0) {  /* active constraint */
+      if (gradient != NULL) {  /* preserve the constraint based on function gradient */
+        if (first_constraint_data)
+          coco_warning("c_linear_cons_bbob_problem_allocate(): first_constraint_data already assigned, this is probably a bug");
+        first_constraint_data = (linear_constraint_data_t *) coco_problem_transformed_get_data(problem_c2);
+      } else
+        con_update_linear_combination(linear_combination, problem_c2, coco_random_uniform(random_generator2));
+    }
+
     problem_c = coco_problem_stacked_allocate(problem_c, problem_c2,
         problem_c2->smallest_values_of_interest, problem_c2->largest_values_of_interest);
-	 
+
     /* Use the standard stacked problem_id as problem_name and 
      * construct a new suite-specific problem_id 
      */
@@ -363,10 +448,31 @@ static coco_problem_t *c_linear_cons_bbob_problem_allocate(const size_t function
     coco_problem_set_type(problem_c, "%s_%s", problem_c2->problem_type, 
         problem_c2->problem_type);
   }
+
+  /* Modify first constraint without changing the feasible solution,
+   * thereby disguising the gradient of the function
+   */
+  if (number_of_active_constraints > 1 && disguise_gradient) {
+    norm = first_constraint_data->gradient_norm;  /* for reading convenience only */
+    gradient = first_constraint_data->gradient;   /* ditto */
+    fac = coco_vector_scalar_product(linear_combination, gradient, dimension);
+    if (fac < 0)
+      coco_error("scalar product between first constraint and linear combination = %f < 0 should be > 0", fac);
+    fac = fac <= 0 ? (double) dimension : coco_double_min((double) dimension, norm * norm / fac);
+    fac *= (1 + coco_random_uniform(random_generator2)) / (2 + 1. / (double) dimension);  /* bound to <1 and >1/3 */
+    for (i = 0; i < dimension; ++i)
+      gradient[i] -= fac * linear_combination[i];
+    fac = coco_vector_norm(gradient, dimension);  /* new gradient norm */
+    if (fac == 0)  /* make sure that gradient did not become zero */
+      coco_error("new vector norm = %f == 0, should be > 0", fac);
+    coco_vector_scale(gradient, dimension, norm, fac); /* restore original norm */
+  }
   
+  coco_free_memory(linear_combination);
   coco_free_memory(gradient_c1);
   coco_random_free(random_generator);
-  
+  coco_random_free(random_generator2);
+
   return problem_c;
  
 }

--- a/code-experiments/src/coco_observer.c
+++ b/code-experiments/src/coco_observer.c
@@ -522,9 +522,9 @@ coco_observer_t *coco_observer(const char *observer_name, const char *observer_o
     observer_biobj(observer, observer_options, &additional_option_keys);
   } else if (0 == strcmp(observer_name, "bbob-biobj-ext")) {
     observer_biobj(observer, observer_options, &additional_option_keys);
-  } else if (0 == strcmp(observer_name, "bbob-largescale")) {
+  } else if (0 == strncmp(observer_name, "bbob-constrained", 16)) {
     observer_bbob(observer, observer_options, &additional_option_keys);
-  } else if (0 == strcmp(observer_name, "bbob-constrained")) {
+  } else if (0 == strcmp(observer_name, "bbob-largescale")) {
     observer_bbob(observer, observer_options, &additional_option_keys);
   } else if (0 == strcmp(observer_name, "bbob-mixint")) {
     observer_bbob(observer, observer_options, &additional_option_keys);

--- a/code-experiments/src/coco_suite.c
+++ b/code-experiments/src/coco_suite.c
@@ -44,8 +44,8 @@ static coco_suite_t *coco_suite_intialize(const char *suite_name) {
     suite = suite_biobj_initialize(suite_name);
   } else if (strcmp(suite_name, "bbob-largescale") == 0) {
     suite = suite_largescale_initialize();
-  } else if (strcmp(suite_name, "bbob-constrained") == 0) {
-    suite = suite_cons_bbob_initialize();
+  } else if (strncmp(suite_name, "bbob-constrained", 16) == 0) {
+    suite = suite_cons_bbob_initialize(suite_name);
   } else if (strcmp(suite_name, "bbob-mixint") == 0) {
     suite = suite_bbob_mixint_initialize(suite_name);
   } else if (strcmp(suite_name, "bbob-biobj-mixint") == 0) {
@@ -69,11 +69,11 @@ static const char *coco_suite_get_instances_by_year(const coco_suite_t *suite, c
 
   if (strcmp(suite->suite_name, "bbob") == 0) {
     year_string = suite_bbob_get_instances_by_year(year);
-  } else if (strcmp(suite->suite_name, "bbob-constrained") == 0) {
-    year_string = suite_cons_bbob_get_instances_by_year(year);
   } else if ((strcmp(suite->suite_name, "bbob-biobj") == 0) ||
       (strcmp(suite->suite_name, "bbob-biobj-ext") == 0)) {
     year_string = suite_biobj_get_instances_by_year(year);
+  } else if (strncmp(suite->suite_name, "bbob-constrained", 16) == 0) {
+    year_string = suite_cons_bbob_get_instances_by_year(year);
   } else if (strcmp(suite->suite_name, "bbob-largescale") == 0) {
     year_string = suite_largescale_get_instances_by_year(year);
   } else if (strcmp(suite->suite_name, "bbob-mixint") == 0) {
@@ -115,10 +115,10 @@ static coco_problem_t *coco_suite_get_problem_from_indices(coco_suite_t *suite,
   } else if ((strcmp(suite->suite_name, "bbob-biobj") == 0) ||
       (strcmp(suite->suite_name, "bbob-biobj-ext") == 0)) {
     problem = suite_biobj_get_problem(suite, function_idx, dimension_idx, instance_idx);
+  } else if (strncmp(suite->suite_name, "bbob-constrained", 16) == 0) {
+    problem = suite_cons_bbob_get_problem(suite, function_idx, dimension_idx, instance_idx);
   } else if (strcmp(suite->suite_name, "bbob-largescale") == 0) {
     problem = suite_largescale_get_problem(suite, function_idx, dimension_idx, instance_idx);
-  } else if (strcmp(suite->suite_name, "bbob-constrained") == 0) {
-    problem = suite_cons_bbob_get_problem(suite, function_idx, dimension_idx, instance_idx);
   } else if (strcmp(suite->suite_name, "bbob-mixint") == 0) {
     problem = suite_bbob_mixint_get_problem(suite, function_idx, dimension_idx, instance_idx);
   } else if (strcmp(suite->suite_name, "bbob-biobj-mixint") == 0) {
@@ -600,7 +600,7 @@ static int coco_suite_is_next_dimension_found(coco_suite_t *suite) {
  * - "bbob-largescale" contains 24 <a href="http://coco.lri.fr/downloads/download15.03/bbobdocfunctions.pdf">
  * single-objective functions</a> in 6 large dimensions (40, 80, 160, 320, 640, 1280)
  * - "bbob-constrained" contains 48 linearly-constrained problems, which are combinations of 8 single 
- * objective functions with 6 different numbers of linear constraints (1, 2, 10, dimension/2, dimension-1, 
+ * objective functions with 6 different numbers of active linear constraints (1, 2, 10, dimension/2, dimension-1,
  * dimension+1), in 6 dimensions (2, 3, 5, 10, 20, 40).
  * - "bbob-mixint" contains mixed-integer single-objective functions in 6 dimensions (2, 3, 5, 10, 20, 40)
  * - "bbob-biobj-mixint" contains 92 mixed-integer bi-objective functions in 6 dimensions (2, 3, 5, 10, 20, 40)

--- a/code-experiments/src/coco_utilities.c
+++ b/code-experiments/src/coco_utilities.c
@@ -1123,6 +1123,24 @@ static double coco_vector_norm(const double *x, size_t dimension) {
 }
 
 /**
+ * @brief return scalar product between vectors x and y.
+ *
+ */
+static double coco_vector_scalar_product(const double *x, const double *y, size_t dimension) {
+
+  size_t i;
+  double ssum = 0.0;
+
+  assert(x);
+  assert(y);
+
+  for (i = 0; i < dimension; ++i)
+    ssum += x[i] * y[i];
+
+  return ssum;
+}
+
+/**
  * @brief Checks if a given matrix M is orthogonal by (partially) computing M * M^T.
  * If M is a square matrix and M * M^T is close enough to the identity matrix
  * (up to a chosen precision), the function returns 1. Otherwise, it returns 0.

--- a/code-experiments/src/suite_cons_bbob.c
+++ b/code-experiments/src/suite_cons_bbob.c
@@ -18,14 +18,14 @@ static coco_suite_t *coco_suite_allocate(const char *suite_name,
 /**
  * @brief Sets the dimensions and default instances for the bbob suite.
  */
-static coco_suite_t *suite_cons_bbob_initialize(void) {
+static coco_suite_t *suite_cons_bbob_initialize(const char *suite_name) {
 
   coco_suite_t *suite;
   const size_t dimensions[] = { 2, 3, 5, 10, 20, 40 };
   const size_t num_dimensions = sizeof(dimensions) / sizeof(dimensions[0]);
 
   /* IMPORTANT: Make sure to change the default instance for every new workshop! */
-  suite = coco_suite_allocate("bbob-constrained", 48, num_dimensions, dimensions, "year: 2016");
+  suite = coco_suite_allocate(suite_name, 54, num_dimensions, dimensions, "year: 2022");
 
   return suite;
 }
@@ -36,7 +36,7 @@ static coco_suite_t *suite_cons_bbob_initialize(void) {
  */
 static const char *suite_cons_bbob_get_instances_by_year(const int year) {
 
-  if ((year == 2016) || (year == 0)) {
+  if ((year == 2022) || (year == 0)) {
     return "1-15";
   }
   else {
@@ -48,7 +48,8 @@ static const char *suite_cons_bbob_get_instances_by_year(const int year) {
 /**
  * @brief Creates and returns a constrained BBOB problem.
  */
-static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
+static coco_problem_t *coco_get_cons_bbob_problem(const char *suite_name,
+                                                  const size_t function,
                                                   const size_t dimension,
                                                   const size_t instance) {
   
@@ -56,14 +57,25 @@ static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
   coco_problem_t *problem = NULL;
   
   double *feasible_direction = coco_allocate_vector(dimension);  
-  double *xopt = coco_allocate_vector(dimension);  
-  double f_0, exponent;
+  double *xopt = coco_allocate_vector(dimension);
+  long rseed = (long) (function + 10000 * instance);
 
   const char *problem_id_template = "bbob-constrained_f%03lu_i%02lu_d%02lu";
   const char *problem_name_template = "bbob-constrained suite problem f%lu instance %lu in %luD";
+  if (strcmp(suite_name, "bbob-constrained-active-only") == 0) {
+    /* CAVEAT: the first 28 chars of this ID are used in c_linear_cons_bbob_problem_allocate()
+     * in c_linear.c to make the decision whether inactive constraints are added */
+    problem_id_template = "bbob-constrained-active-only_f%03lu_i%02lu_d%02lu";
+    problem_name_template = "bbob-constrained-active-only suite problem f%lu instance %lu in %luD";
+  }
+  if (strcmp(suite_name, "bbob-constrained-no-disguise") == 0) {
+    /* First trick as above, by chance same number of characters
+     * Both options at the same time not supported */
+    problem_id_template = "bbob-constrained-no-disguise_f%03lu_i%02lu_d%02lu";
+    problem_name_template = "bbob-constrained-no-disguise suite problem f%lu instance %lu in %luD";
+  }
   
   /* Seed value used for shifting the whole constrained problem */
-  long rseed = (long) (function + 10000 * instance);
   bbob2009_compute_xopt(xopt, rseed, dimension);
   
   /* Choose a different seed value for building the objective function */
@@ -77,13 +89,15 @@ static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
-	 
+    problem = transform_obj_scale(problem, 10.);  /* move initial feasible point to a delta-f between 100 and 10000 */
+
   } else if (obj_function_type(function) == 2) {
 	  
     problem = f_ellipsoid_c_linear_cons_bbob_problem_allocate(function, 
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
+    problem = transform_obj_scale(problem, 1e-4);  /* move initial feasible point to a delta-f between 100 and 10000 */
 	  
   } else if (obj_function_type(function) == 3) {
 	  
@@ -91,6 +105,7 @@ static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
+    problem = transform_obj_scale(problem, 10.);  /* move initial feasible point to a delta-f between 100 and 10000 */
 	  
   } else if (obj_function_type(function) == 4) {
 	  
@@ -98,6 +113,7 @@ static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
+    problem = transform_obj_scale(problem, 1e-4);  /* move initial feasible point to a delta-f between 100 and 10000 */
 	  
   } else if (obj_function_type(function) == 5) {
 	  
@@ -105,6 +121,7 @@ static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
+    problem = transform_obj_scale(problem, 1e-4);  /* move initial feasible point to a delta-f between 100 and 10000 */
 	  
   } else if (obj_function_type(function) == 6) {
 	  
@@ -112,6 +129,7 @@ static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
+    problem = transform_obj_scale(problem, 1e-4);  /* move initial feasible point to a delta-f between 100 and 100,000 */
 	  
   } else if (obj_function_type(function) == 7) {
 	  
@@ -119,27 +137,30 @@ static coco_problem_t *coco_get_cons_bbob_problem(const size_t function,
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
-	  
+    problem = transform_obj_scale(problem, 1e2);  /* move initial feasible point to a delta-f between 100 and 1000 */
+
   } else if (obj_function_type(function) == 8) {
-	  
+      
     problem = f_rastrigin_c_linear_cons_bbob_problem_allocate(function, 
         dimension, instance, number_of_linear_constraints, rseed,
         feasible_direction, xopt, problem_id_template, 
         problem_name_template);
-	  
+    problem = transform_obj_scale(problem, 10.);  /* move initial feasible point to a delta-f between 100 and 10000 */
+
+  } else if (obj_function_type(function) == 9) {
+      
+    problem = f_rastrigin_rotated_c_linear_cons_bbob_problem_allocate(function, 
+        dimension, instance, number_of_linear_constraints, rseed,
+        feasible_direction, xopt, problem_id_template, 
+        problem_name_template);
+    problem = transform_obj_scale(problem, 10.);  /* move initial feasible point to a delta-f between 100 and 10000 */
+      
   } else {
     coco_error("get_cons_bbob_problem(): cannot retrieve problem f%lu instance %lu in %luD", 
         function, instance, dimension);
     coco_free_memory(xopt);
     coco_free_memory(feasible_direction);
     return NULL; /* Never reached */
-  }
-
-  /* Scale down the objective function value */
-  exponent = -2./3;
-  f_0 = coco_problem_get_best_value(problem);
-  if (f_0 > 1e3) {
-    problem = transform_obj_scale(problem, pow(f_0, exponent));
   }
 
   coco_free_memory(xopt);
@@ -169,7 +190,7 @@ static coco_problem_t *suite_cons_bbob_get_problem(coco_suite_t *suite,
   const size_t dimension = suite->dimensions[dimension_idx];
   const size_t instance = suite->instances[instance_idx];
 
-  problem = coco_get_cons_bbob_problem(function, dimension, instance);
+  problem = coco_get_cons_bbob_problem(suite->suite_name, function, dimension, instance);
 
   problem->suite_dep_function = function;
   problem->suite_dep_instance = instance;
@@ -178,9 +199,10 @@ static coco_problem_t *suite_cons_bbob_get_problem(coco_suite_t *suite,
   /* Use the standard stacked problem_id as problem_name and 
    * construct a new suite-specific problem_id 
    */
-  coco_problem_set_name(problem, problem->problem_id);
-  coco_problem_set_id(problem, "bbob-constrained_f%02lu_i%02lu_d%02lu", 
-  (unsigned long)function, (unsigned long)instance, (unsigned long)dimension);
+  coco_problem_set_id(problem, "%s_f%03lu_i%02lu_d%02lu",
+    suite->suite_name, (unsigned long)function, (unsigned long)instance, (unsigned long)dimension);
+  coco_problem_set_name(problem, "%s suite problem f%lu instance %lu in %luD",
+    suite->suite_name, (unsigned long)function, (unsigned long)instance, (unsigned long)dimension);
   
   return problem;
 }


### PR DESCRIPTION
This PR to merge into the current development branch the last features we developed for the constrained test suite:
- Inactive constraints
- Active and inactive constraints indices are randomly shuffled
- The first constraint is modified to avoid trivial Lagrange multipliers
- The rotated Rastrigin is added to the list of test problems
- Unofficial supplementary suites
   - `bbob-constrained-no-disguise` (where the Lagrange multipliers are `[1, 0, ..., 0]`)
   -  `bbob-constrained-active-only` which describes itself 