### PR TITLE
Constrained test suite with 54 functions

### DIFF
--- a/code-postprocessing/cocopp/ppfig.py
+++ b/code-postprocessing/cocopp/ppfig.py
@@ -292,11 +292,11 @@ def save_single_functions_html(filename,
         if function_groups is None:
             function_groups = OrderedDict([])
 
-        function_group = "nzall" if genericsettings.isNoisy else "noiselessall"
-        if htmlPage not in (HtmlPage.PPRLDMANY_BY_GROUP, HtmlPage.PPLOGLOSS):
-            temp_function_groups = OrderedDict([(function_group, 'All functions')])
-            temp_function_groups.update(function_groups)
-            function_groups = temp_function_groups
+        if not testbedsettings.current_testbed.name.startswith("bbob-constrained"):
+            function_group = "nzall" if genericsettings.isNoisy else "noiselessall"
+            if htmlPage not in (HtmlPage.PPRLDMANY_BY_GROUP, HtmlPage.PPLOGLOSS):
+                function_groups.update(
+                    OrderedDict([(function_group, 'All functions')]))  # append the noiselesall group at the end
 
         first_function_number = testbedsettings.current_testbed.first_function_number
         last_function_number = testbedsettings.current_testbed.last_function_number

--- a/code-postprocessing/cocopp/pproc.py
+++ b/code-postprocessing/cocopp/pproc.py
@@ -2375,6 +2375,7 @@ class DataSetList(list):
 
     def isBiobjective(self):
         return any(i.isBiobjective() for i in self)
+
         
     def dictByFuncGroupBiobjective(self):
         """Returns a dictionary of instances of this class by function groups
@@ -2400,44 +2401,50 @@ class DataSetList(list):
 
         The output dictionary has function group names as keys and the
         corresponding slices as values. Current groups are based on the
-        GECCO-BBOB 2009-2013 function testbeds. 
-
+        GECCO-BBOB 2009-2013 function testbeds.
         """
-        sorted = {} 
+        res = {}
 
         # TODO: this should be done in the testbed, not here
         if testbedsettings.current_testbed.name == 'bbob-constrained':
             for i in self:
+                n_constraints = testbedsettings.current_testbed.constraint_category(i.funcId)
+                res.setdefault(  #  splitting only by n of constraints
+                    'all m=' + n_constraints, DataSetList()).append(i)
+                # splitting by n of constraints and function class
                 if i.funcId in range(1, 19):
-                    sorted.setdefault('separ', DataSetList()).append(i)
+                    res.setdefault(
+                        'separ m=' + n_constraints, DataSetList()).append(i)
                 elif i.funcId in range(19, 43):
-                    sorted.setdefault('hcond', DataSetList()).append(i)
+                    res.setdefault(
+                        'hcond m=' + n_constraints, DataSetList()).append(i)
                 elif i.funcId in range(43, 49):
-                    sorted.setdefault('multi', DataSetList()).append(i)
+                    res.setdefault(
+                        'multi m=' + n_constraints, DataSetList()).append(i)
                 else:
                     warnings.warn('Unknown function id.')
         else:
             for i in self:
                 if i.funcId in range(1, 6):
-                    sorted.setdefault('separ', DataSetList()).append(i)
+                    res.setdefault('separ', DataSetList()).append(i)
                 elif i.funcId in range(6, 10):
-                    sorted.setdefault('lcond', DataSetList()).append(i)
+                    res.setdefault('lcond', DataSetList()).append(i)
                 elif i.funcId in range(10, 15):
-                    sorted.setdefault('hcond', DataSetList()).append(i)
+                    res.setdefault('hcond', DataSetList()).append(i)
                 elif i.funcId in range(15, 20):
-                    sorted.setdefault('multi', DataSetList()).append(i)
+                    res.setdefault('multi', DataSetList()).append(i)
                 elif i.funcId in range(20, 25):
-                    sorted.setdefault('mult2', DataSetList()).append(i)
+                    res.setdefault('mult2', DataSetList()).append(i)
                 elif i.funcId in range(101, 107):
-                    sorted.setdefault('nzmod', DataSetList()).append(i)
+                    res.setdefault('nzmod', DataSetList()).append(i)
                 elif i.funcId in range(107, 122):
-                    sorted.setdefault('nzsev', DataSetList()).append(i)
+                    res.setdefault('nzsev', DataSetList()).append(i)
                 elif i.funcId in range(122, 131):
-                    sorted.setdefault('nzsmm', DataSetList()).append(i)
+                    res.setdefault('nzsmm', DataSetList()).append(i)
                 else:
                     warnings.warn('Unknown function id.')
                     
-        return sorted
+        return res
 
     def dictByFuncGroup(self):
         """Returns a dictionary of instances of this class by function groups.
@@ -2463,14 +2470,29 @@ class DataSetList(list):
             return groups
         elif testbedsettings.current_testbed.name == 'bbob-constrained':
             groups = []
-            if any(i.funcId in range(1, 19) for i in self):
-                groups.append(('separ', 'Separable functions'))
-            if any(i.funcId in range(19, 43) for i in self):
-                groups.append(('hcond', 'Ill-conditioned functions'))
-            if any(i.funcId in range(43, 49) for i in self):
-                groups.append(('multi', 'Multi-modal functions'))
-
-            return OrderedDict(groups)
+            for i in self:
+                n_constraints = testbedsettings.current_testbed.constraint_category(i.funcId)
+                n_cons_dim = testbedsettings.current_testbed.number_of_constraints(i.dim, i.funcId)
+                groups.append(
+                    (3, n_cons_dim,
+                     ('all m=' + n_constraints,
+                     'All functions with n_constraints' + 'constraints')))
+                if i.funcId in range(1, 19):
+                    groups.append( # first two entries are for sorting only, dropped later
+                        (0, n_cons_dim,
+                         ('separ m=' + n_constraints,
+                         'Separable functions with' + n_constraints + 'constraints')))
+                elif i.funcId in range(19, 43):
+                    groups.append(
+                        (1, n_cons_dim,
+                         ('hcond m=' + n_constraints,
+                         'Ill-conditioned functions with' + n_constraints + 'constraints')))
+                elif any(i.funcId in range(43, 49) for i in self):
+                    groups.append(
+                        (2, n_cons_dim,
+                         ('multi m=' + n_constraints,
+                         'Multi-modal functions with' + n_constraints + 'constraints')))
+            return OrderedDict([_[-1] for _ in sorted(groups)])  # remove duplicates, keep order
         else:
             groups = []
             if any(i.funcId in range(1, 6) for i in self):

--- a/code-postprocessing/cocopp/rungenericmany.py
+++ b/code-postprocessing/cocopp/rungenericmany.py
@@ -305,15 +305,18 @@ def main(args, outputdir):
                                            '%s' % fGroup)
                 print_done()  # of "ECDF runlength graphs..."
 
-        # ECDFs per noise groups
-        print("ECDF graphs per noise group...")
-        grouped_ecdf_graphs(pproc.dictAlgByNoi(dictAlg),
-                            sortedAlgs,
-                            many_algorithms_output,
-                            dictAlg[sortedAlgs[0]].getFuncGroups(),
-                            genericsettings,
-                            genericsettings.many_algorithm_file_name)
-        print_done()
+        if testbedsettings.current_testbed.name.startswith("bbob-constrained"):
+            print("Skipping aggregation of all functions for bbob-constrained* suite")
+        else:
+            # ECDFs per noise groups
+            print("ECDF graphs per noise group...")
+            grouped_ecdf_graphs(pproc.dictAlgByNoi(dictAlg),
+                                sortedAlgs,
+                                many_algorithms_output,
+                                dictAlg[sortedAlgs[0]].getFuncGroups(),
+                                genericsettings,
+                                genericsettings.many_algorithm_file_name)
+            print_done()
 
         # ECDFs per function groups
         print("ECDF graphs per function group...")

--- a/code-postprocessing/cocopp/testbedsettings.py
+++ b/code-postprocessing/cocopp/testbedsettings.py
@@ -59,6 +59,8 @@ suite_to_testbed = {
     default_suite_bi: default_testbed_bi,
     'bbob-biobj-ext': default_testbed_bi_ext,
     'bbob-constrained': default_testbed_cons,
+    'bbob-constrained-active-only': default_testbed_cons,
+    'bbob-constrained-no-disguise': default_testbed_cons,
     'bbob-largescale': default_testbed_ls,
     'bbob-mixint': default_testbed_mixint,
     'bbob-biobj-mixint': 'GECCOBBOBBiObjMixintTestbed',
@@ -456,6 +458,43 @@ class CONSBBOBTestbed(GECCOBBOBTestbed):
     def filter(self, dsl):
         """ Does nothing but overwriting the method from superclass"""
         return dsl
+
+    @staticmethod
+    def number_of_constraints(dimension, function_id, active_only=False):
+        """Return the number of constraints of function `function_id`
+
+        in the given dimension. If `active_only`, it is the number of
+        constraints that are active in the global optimum.
+        """
+
+        if active_only:
+            numbers = [1, 2, 6, 6 + int(dimension / 2),
+                       6 + dimension, 6 + 3 * dimension]
+        else:
+            numbers = [1, 3, 9, 9 + 3 * int(dimension / 4),
+                       9 + 3 * int(dimension / 2), 9 + 9 * int(dimension / 2)]
+
+        map_id_to_number = {k: n for k, n in enumerate(numbers)}
+
+        return map_id_to_number[(function_id - 1) % 6]  # 6 is also len(numbers)
+
+    @staticmethod
+    def constraint_category(function_id, active_only=False):
+        """Return the number of constraints as a string formula.
+
+        The formula is the same for all dimensions and may contain 'n'
+        which stands for dimension. If `active_only`, it gives the number
+        of constraints that are active in the global optimum.
+        """
+
+        if active_only:
+            numbers = ['1', '2', '6', '6+n2', '6+n', '6+3n']
+        else:
+            numbers = ['0n+1', '0n+3', '0n+9', '3ndiv4+9', '6ndiv4+9', '9ndiv2+9']
+
+        map_id_to_number = {k: n for k, n in enumerate(numbers)}
+
+        return map_id_to_number[(function_id - 1) % 6]  # 6 is also len(numbers)
 
 
 class GECCOBBOBNoisyTestbed(GECCOBBOBTestbed):


### PR DESCRIPTION
As #2052 

This PR to merge into the current development branch the last features we developed for the constrained test suite:
- Inactive constraints
- Active and inactive constraints indices are randomly shuffled
- The first constraint is modified to avoid trivial Lagrange multipliers
- The rotated Rastrigin is added to the list of test problems
- Unofficial supplementary suites
   - `bbob-constrained-no-disguise` (where the Lagrange multipliers are `[1, 0, ..., 0]`)
   -  `bbob-constrained-active-only` which describes itself 