### PR TITLE
Fix the CircleCI broken pipe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,10 @@ jobs:
           command: ln -s /usr/bin/python3 /usr/bin/python
       - run:
           name: Install coco python
-          command: python3 do.py run-python
+          command: python3 do.py run-python install-user
       - run:
           name: Install coco post-processing
-          command: python3 do.py install-postprocessing
+          command: python3 do.py install-postprocessing install-user
       - run:
           name: Run the example experiment
           command: |
@@ -83,11 +83,11 @@ jobs:
           no_output_timeout: 1800
       - run:
           name: Run coco pre-processing tests
-          command: python3 do.py test-preprocessing
+          command: python3 do.py test-preprocessing install-user
           no_output_timeout: 1800
       - run:
           name: Run coco post-processing tests
-          command: python3 do.py test-postprocessing
+          command: python3 do.py test-postprocessing install-user
           no_output_timeout: 5400
       - run:
           name: Run coco C


### PR DESCRIPTION
It seems a recent update on the CircleCI machine broke the tests as the installed modules were not found anymore. This PR consists of one single commit with is the merge of 4 commits as I hadd to add the option in a few places  (reproduced here for history)

- add install-user option in circleci

- correct mistake in circleci

- as expected, install-user also needed to install cocopp

- install-user in do.py test-* as well