### PR TITLE
Experiment: Add example CMake and meson build files

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,26 @@
+name: CMake
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    branches: [ master, development ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build C amalgamation
+      run: python ${{github.workspace}}/do.py build-c
+      
+    - name: Configure CMake
+      run: cmake -S ${{github.workspace}}/code-experiments/build/c/ -B ${{github.workspace}}/code-experiments/build/c/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/code-experiments/build/c/build --config ${{env.BUILD_TYPE}}

--- a/code-experiments/build/c/CMakeLists.txt
+++ b/code-experiments/build/c/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.19)
+project(ExampleExperiment
+  DESCRIPTION "Example COCO experiment"
+  LANGUAGES C)
+
+find_library(MATH_LIBRARY m)
+
+include(CheckCompilerFlag)
+check_compiler_flag(C "-pedantic -Wall -Wextra -Wstrict-prototypes -Wshadow -Wno-sign-compare -Wconversion" CC_HAS_WALL_ETC)
+
+add_library(coco STATIC coco.c coco.h)
+target_include_directories(coco PUBLIC .)
+if(MATH_LIBRARY)
+    target_link_libraries(coco PUBLIC ${MATH_LIBRARY})
+endif()
+# Add warning flags
+if (MSVC)
+  target_compile_options(coco PRIVATE "/W3")
+elseif (CC_HAS_WALL_ETC)
+  target_compile_options(coco PRIVATE -pedantic -Wall -Wextra -Wstrict-prototypes -Wshadow -Wno-sign-compare -Wconversion)
+endif()
+
+add_executable(example_experiment example_experiment.c)
+target_link_libraries(example_experiment PUBLIC coco)
+if(MATH_LIBRARY)
+    target_link_libraries(example_experiment PUBLIC ${MATH_LIBRARY})
+endif()

--- a/code-experiments/build/c/Makefile.in
+++ b/code-experiments/build/c/Makefile.in
@@ -13,7 +13,7 @@
 ## or installing Cygwin and running GNU make from within Cygwin.
 
 LDFLAGS += -lm
-CCFLAGS = -g -ggdb -std=c89 -pedantic -Wall -Wextra -Wstrict-prototypes -Wshadow -Wno-sign-compare -Wconversion
+CCFLAGS ?= -g -ggdb -std=c89 -pedantic -Wall -Wextra -Wstrict-prototypes -Wshadow -Wno-sign-compare -Wconversion
 
 ########################################################################
 ## Toplevel targets

--- a/code-experiments/build/c/README.md
+++ b/code-experiments/build/c/README.md
@@ -34,6 +34,15 @@ cmake ../
 ninja # or make, depending on your version of CMake
 ```
 
+### meson
+
+Instead of `make` you can use `meson` and `ninja`: 
+
+```
+meson setup build
+meson compile -C build
+```
+
 Getting Started
 ---------------
 

--- a/code-experiments/build/c/README.md
+++ b/code-experiments/build/c/README.md
@@ -23,6 +23,16 @@ the following is lacking:
 
 Instead of `make` and `Makefile` you can use `nmake` and the corresponding `NMakefile`
 
+### CMake
+
+Instead of `make` you can use `cmake` and the corresponding `CMakeLists.txt`:
+
+```
+mkdir build
+cd build
+cmake ../
+ninja # or make, depending on your version of CMake
+```
 
 Getting Started
 ---------------

--- a/code-experiments/build/c/meson.build
+++ b/code-experiments/build/c/meson.build
@@ -1,0 +1,18 @@
+project('example_experiment', 'c',
+  default_options: ['warning_level=3', 'buildtype=release']
+  )
+
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required : false)
+
+coco_lib = static_library('coco', 
+  sources: 'coco.c',
+  dependencies: m_dep
+  )
+
+executable('example_experiment', 
+  sources: 'example_experiment.c',
+  link_with: coco_lib,
+  dependencies: m_dep
+  )
+


### PR DESCRIPTION
CMake and meson are build systems that have both gained popularity. This PR adds example build files for both so that users might use them as starting points if their project already uses CMake or meson. It should also be a good option for users on Windows where CMake can generate Visual Studio project files.