### PR TITLE
Add `.gitignore` files for c and python.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ REVISION
 # build files
 __pycache__
 *.o
+
+# tests
+code-experiments/test/example-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+VERSION
+REVISION
+
+# build files
+__pycache__
+*.o

--- a/code-experiments/build/c/.gitignore
+++ b/code-experiments/build/c/.gitignore
@@ -1,5 +1,8 @@
 coco.c
 coco.h
-example_experiment
+
 Makefile
 Makefile_win_gcc
+
+exdata/
+example_experiment

--- a/code-experiments/build/c/.gitignore
+++ b/code-experiments/build/c/.gitignore
@@ -1,0 +1,5 @@
+coco.c
+coco.h
+example_experiment
+Makefile
+Makefile_win_gcc

--- a/code-experiments/build/python/.gitignore
+++ b/code-experiments/build/python/.gitignore
@@ -1,0 +1,8 @@
+cython/coco.c
+cython/coco.h
+
+setup.py
+README.txt
+
+bbob2009_testcases.txt
+bbob2009_testcases2.txt

--- a/code-experiments/examples/.gitignore
+++ b/code-experiments/examples/.gitignore
@@ -1,0 +1,2 @@
+coco.c
+coco.h

--- a/code-experiments/test/integration-test/.gitignore
+++ b/code-experiments/test/integration-test/.gitignore
@@ -1,0 +1,13 @@
+coco.c
+coco.h
+
+Makefile
+test_bbob-constrained
+test_bbob-largescale
+test_bbob-mixint
+test_biobj
+test_coco
+test_instance_extraction
+
+bbob2009_testcases.txt
+bbob2009_testcases2.txt

--- a/code-experiments/test/unit-test/.gitignore
+++ b/code-experiments/test/unit-test/.gitignore
@@ -1,0 +1,5 @@
+coco.c
+coco.h
+
+Makefile
+unit_test


### PR DESCRIPTION
This covers the following commands:
- `build-c`
- `run-c`
- `test-c`
- `build-python`
- `build-rust`
- `run-rust`
- `test-rust`

It does not cover:
- `run-python`
- `*-java`
- `*-matlab`

This is only due to me not having these setup on my computer, but they would be easy to add for someone who has them.