### PR TITLE
Update Rust bindings.

### DIFF
--- a/code-experiments/build/rust/Cargo.toml
+++ b/code-experiments/build/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coco-rs"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Leopold Luley"]
 description = "Rust bindings for COCO benchmarking framework"
@@ -13,5 +13,5 @@ edition = "2021"
 members = ["coco-sys"]
 
 [dependencies.coco-sys]
-version = "0.3"
+version = "0.4"
 path="./coco-sys"

--- a/code-experiments/build/rust/coco-sys/Cargo.toml
+++ b/code-experiments/build/rust/coco-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coco-sys"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Leopold Luley"]
 description = "Generated Rust bindings for COCO benchmarking framework"

--- a/code-experiments/build/rust/src/lib.rs
+++ b/code-experiments/build/rust/src/lib.rs
@@ -140,6 +140,38 @@ impl Suite {
         })
     }
 
+    /// Returns the problem for the given function, dimension and instance.
+    ///
+    /// While a suite can contain multiple problems with equal function, dimension and instance, this
+    /// function always returns the first problem in the suite with the given function, dimension and instance
+    /// values. If the given values don't correspond to a problem, the function returns `None`.
+    pub fn problem_by_function_dimension_instance(
+        &mut self,
+        function: usize,
+        dimension: usize,
+        instance: usize,
+    ) -> Option<Problem> {
+        let problem = unsafe {
+            coco_sys::coco_suite_get_problem_by_function_dimension_instance(
+                self.inner,
+                function as u64,
+                dimension as u64,
+                instance as u64,
+            )
+        };
+
+        if problem.is_null() {
+            return None;
+        }
+
+        Some(Problem {
+            inner: problem,
+            function,
+            dimension,
+            instance,
+        })
+    }
+
     /// Returns the total number of problems in the suite.
     pub fn number_of_problems(&self) -> usize {
         unsafe {


### PR DESCRIPTION
This has three changes:
- Added missing `Suite::problem_by_function_dimension_instance` function
- Prevent `Problem` from outliving its `Suite`
- Incorporate internal `C` code changes into the Rust package