### PR TITLE
Fix Rust's readme

### DIFF
--- a/code-experiments/build/rust/README.md
+++ b/code-experiments/build/rust/README.md
@@ -13,7 +13,7 @@ See https://github.com/numbbo/coco and https://numbbo.github.io/coco/.
 
 - `git`
 - `gcc` (or any other C compiler)
-- `bindgen` (`cargo install bindgen`)
+- `bindgen` (`cargo install bindgen-cli`)
     - and `libclang` (install `libclang-dev` on Ubuntu)
 - `bash` (for `generate.sh`)
 


### PR DESCRIPTION
Hi!
I've been playing around with Rust and COCO and noticed that there is a minor mistake in Rust build instructions.

Running `cargo install bindgen` results in following error:

```
❯ cargo install bindgen
    Updating crates.io index
error: there is nothing to install in `bindgen v0.63.0`, because it has no binaries
`cargo install` is only for installing programs, and can't be used with libraries.
To use a library crate, add it as a dependency in a Cargo project instead.
```

Looking at [`crates.io`](https://crates.io/crates/bindgen-cli/versions) it seems that `bindgen-cli` is published separately since October 2022 (done [here](https://github.com/rust-lang/rust-bindgen/commit/0296f9e86c7756e718b6b82836ce1e09b5f8d08a) most likely). 

Suggesting this change, because as I'm just starting playing around I've spent some time scratching my head why id does not work.  