### PR TITLE
[WIP] Update `meson.build` script

### DIFF
--- a/code-experiments/build/c/meson.build
+++ b/code-experiments/build/c/meson.build
@@ -4,21 +4,24 @@ project('coco', 'c',
 
 cc = meson.get_compiler('c')
 m_dep = cc.find_library('m', required : false)
+inc = include_directories('../../src')
 
-coco_lib = static_library('coco', 
-  sources: 'coco.c',
-  dependencies: m_dep
+coco_lib = static_library('coco',
+  sources: '../../src/coco_suite.c',
+  dependencies: m_dep,
   )
 
-executable('example_experiment', 
+executable('example_experiment',
   sources: 'example_experiment.c',
   link_with: coco_lib,
-  dependencies: m_dep
+  dependencies: m_dep,
+  include_directories: inc
   )
 
-executable('test_coco', 
+executable('test_coco',
   sources: 'test_coco.c',
   link_with: coco_lib,
-  dependencies: m_dep
+  dependencies: m_dep,
+  include_directories: inc
   )
 


### PR DESCRIPTION
I tried to use the script to compile the problems library but have been running into multiple issues. With this PR I would like to reach a state where this compiles.  This has pretty several problems still, I am running into a lot of redefinition errors 

```
FAILED: libcoco.a.p/.._.._src_coco_suite.c.o 
cc -Ilibcoco.a.p -I. -I.. -fdiagnostics-color=always -Wall -Winvalid-pch -Wextra -Wpedantic -O3 -MD -MQ libcoco.a.p/.._.._src_coco_suite.c.o -MF libcoco.a.p/.._.._src_coco_suite.c.o.d -o libcoco.a.p/.._.._src_coco_suite.c.o -c ../../../src/coco_suite.c
In file included from ../../../src/coco_suite.c:18:
In file included from ../../../src/suite_bbob_noisy.c:6:
In file included from ../../../src/transform_obj_gaussian_noise.c:6:
In file included from ../../../src/suite_bbob_noisy_utilities.c:10:
In file included from ../../../src/coco_problem.c:10:
In file included from ../../../src/coco_utilities.c:19:
../../../src/coco_string.c:21:14: error: redefinition of 'coco_strdup'
static char *coco_strdup(const char *string) {
             ^
../../../src/coco_string.c:21:14: note: previous definition is here
static char *coco_strdup(const char *string) {
```

which doesn't make sense.