### PR TITLE
This was an error in the implementation

### DIFF
--- a/code-experiments/src/f_katsuura.c
+++ b/code-experiments/src/f_katsuura.c
@@ -43,7 +43,7 @@ static double f_katsuura_raw(const double *x, const size_t number_of_variables) 
   }
   /*result = 10. / ((double) number_of_variables) / ((double) number_of_variables)
       * (-1. + pow(result, 10. / pow((double) number_of_variables, 1.2)));*/
-  result = 10. / ((double) number_of_variables) / ((double) number_of_variables)
+  result = 10. / ((double) number_of_variables) * ((double) number_of_variables)
   * (-1. + result);
 
   return result;


### PR DESCRIPTION

![Captura de pantalla de 2024-11-13 17-34-02](https://github.com/user-attachments/assets/c27db28a-74ac-4e02-8f5f-569aa1ab89a4)
Besides being equivalent to 1 that way, you need to go no further than the formula (above). It is now equivalent to D^2; before it was simply 1.